### PR TITLE
Topic/operator equal

### DIFF
--- a/include/curves/bernstein.h
+++ b/include/curves/bernstein.h
@@ -45,6 +45,17 @@ struct Bern {
     return bin_m_i_ * (pow(u, i_)) * pow((1 - u), m_minus_i);
   }
 
+  virtual bool operator== (const Bern& other) const{
+    return m_minus_i == other.m_minus_i
+        && i_ == other.i_
+        && bin_m_i_ == other.bin_m_i_;
+  }
+
+  virtual bool operator!=(const Bern& other) const {
+    return !(*this == other);
+  }
+
+
   /* Attributes */
   Numeric m_minus_i;
   Numeric i_;

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -140,6 +140,30 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
     }
   }
 
+  virtual bool operator==(const bezier_curve_t& other) const {
+    //std::cout<<"operator == between bezier called."<<std::endl;
+    return  T_min_ == other.min()
+        && T_max_ == other.max()
+        && dim_ == other.dim()
+        && degree_ == other.degree()
+        && size_ == other.size_
+        && mult_T_ == other.mult_T_
+        && bernstein_ == other.bernstein_;
+  }
+
+  virtual bool operator!=(const bezier_curve_t& other) const {
+    return !(*this == other);
+  }
+
+  virtual bool operator==(const curve_abc_t& other) const {
+    return curve_abc_t::isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_abc_t& other) const {
+    return !curve_abc_t::isApprox(other);
+  }
+
+
   ///  \brief Compute the derived curve at order N.
   ///  Computes the derivative order N, \f$\frac{d^Nx(t)}{dt^N}\f$ of bezier curve of parametric equation x(t).
   ///  \param order : order of derivative.

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -144,10 +144,11 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   ///  Computes the derivative order N, \f$\frac{d^Nx(t)}{dt^N}\f$ of bezier curve of parametric equation x(t).
   ///  \param order : order of derivative.
   ///  \return \f$\frac{d^Nx(t)}{dt^N}\f$ derivative order N of the curve.
-  curve_ptr_t compute_derivate(const std::size_t order) const {
+  bezier_curve_t* compute_derivate(const std::size_t order) const {
     check_conditions();
-    if(order < 1)
-      throw std::invalid_argument("ORDER argument for compute_derivate must be >= 1 .");
+    if (order == 0) {
+      return new bezier_curve_t(*this);
+    }
     t_point_t derived_wp;
     for (typename t_point_t::const_iterator pit = control_points_.begin(); pit != control_points_.end() - 1; ++pit) {
       derived_wp.push_back((num_t)degree_ * (*(pit + 1) - (*pit)));
@@ -155,11 +156,9 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
     if (derived_wp.empty()) {
       derived_wp.push_back(point_t::Zero(dim_));
     }
-    curve_ptr_t deriv(new bezier_curve_t(derived_wp.begin(), derived_wp.end(), T_min_, T_max_, mult_T_ * (1. / (T_max_ - T_min_))));
-    if(order == 1)
-      return deriv;
-    else
-      return deriv->compute_derivate(order - 1);
+    bezier_curve_t deriv(derived_wp.begin(), derived_wp.end(), T_min_, T_max_, mult_T_ * (1. / (T_max_ - T_min_)));
+    return deriv.compute_derivate(order - 1);
+
   }
 
   ///  \brief Compute the primitive of the curve at order N.
@@ -194,8 +193,10 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   ///  \return \f$\frac{d^Nx(t)}{dt^N}\f$ point corresponding on derived curve of order N at time t.
   ///
   virtual point_t derivate(const time_t t, const std::size_t order) const {
-    curve_ptr_t deriv = compute_derivate(order);
-    return (*deriv)(t);
+    bezier_curve_t* deriv = compute_derivate(order);
+    point_t res((*deriv)(t));
+    delete deriv;
+    return res;
   }
 
   /// \brief Evaluate all Bernstein polynomes for a certain degree.

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -414,6 +414,9 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   /// \brief Get the maximum time for which the curve is defined.
   /// \return \f$t_{max}\f$, upper bound of time range.
   virtual time_t max() const { return T_max_; }
+  /// \brief Get the degree of the curve.
+  /// \return \f$degree\f$, the degree of the curve.
+  virtual std::size_t  degree() const {return degree_;}
   /*Helpers*/
 
   /* Attributes */

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -41,6 +41,7 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   typedef bezier_curve<Time, Numeric, Safe, Point> bezier_curve_t;
   typedef piecewise_curve<Time, Numeric, Safe, point_t> piecewise_curve_t;
   typedef curve_abc<Time, Numeric, Safe, point_t> curve_abc_t;  // parent class
+  typedef typename curve_abc_t::curve_ptr_t curve_ptr_t;
 
   /* Constructors - destructors */
  public:
@@ -142,11 +143,10 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   ///  Computes the derivative order N, \f$\frac{d^Nx(t)}{dt^N}\f$ of bezier curve of parametric equation x(t).
   ///  \param order : order of derivative.
   ///  \return \f$\frac{d^Nx(t)}{dt^N}\f$ derivative order N of the curve.
-  bezier_curve_t compute_derivate(const std::size_t order) const {
+  curve_ptr_t compute_derivate(const std::size_t order) const {
     check_conditions();
-    if (order == 0) {
-      return *this;
-    }
+    if(order < 1)
+      throw std::invalid_argument("ORDER argument for compute_derivate must be >= 1 .");
     t_point_t derived_wp;
     for (typename t_point_t::const_iterator pit = control_points_.begin(); pit != control_points_.end() - 1; ++pit) {
       derived_wp.push_back((num_t)degree_ * (*(pit + 1) - (*pit)));
@@ -154,8 +154,11 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
     if (derived_wp.empty()) {
       derived_wp.push_back(point_t::Zero(dim_));
     }
-    bezier_curve_t deriv(derived_wp.begin(), derived_wp.end(), T_min_, T_max_, mult_T_ * (1. / (T_max_ - T_min_)));
-    return deriv.compute_derivate(order - 1);
+    curve_ptr_t deriv(new bezier_curve_t(derived_wp.begin(), derived_wp.end(), T_min_, T_max_, mult_T_ * (1. / (T_max_ - T_min_))));
+    if(order == 1)
+      return deriv;
+    else
+      return deriv->compute_derivate(order - 1);
   }
 
   ///  \brief Compute the primitive of the curve at order N.
@@ -190,8 +193,8 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   ///  \return \f$\frac{d^Nx(t)}{dt^N}\f$ point corresponding on derived curve of order N at time t.
   ///
   virtual point_t derivate(const time_t t, const std::size_t order) const {
-    bezier_curve_t deriv = compute_derivate(order);
-    return deriv(t);
+    curve_ptr_t deriv = compute_derivate(order);
+    return (*deriv)(t);
   }
 
   /// \brief Evaluate all Bernstein polynomes for a certain degree.

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -140,15 +140,29 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
     }
   }
 
-  virtual bool operator==(const bezier_curve_t& other) const {
-    //std::cout<<"operator == between bezier called."<<std::endl;
-    return  T_min_ == other.min()
+  virtual bool isApprox(const bezier_curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    //std::cout<<"is approx in bezier called."<<std::endl;
+    (void)order;
+    bool equal = T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()
         && degree_ == other.degree()
         && size_ == other.size_
         && mult_T_ == other.mult_T_
         && bernstein_ == other.bernstein_;
+    if(!equal)
+      return false;
+    for (size_t i = 0 ;i < size_;++i)
+    {
+      if(!control_points_.at(i).isApprox(other.control_points_.at(i),prec))
+        return false;
+    }
+    return true;
+  }
+
+
+  virtual bool operator==(const bezier_curve_t& other) const {
+    return isApprox(other);
   }
 
   virtual bool operator!=(const bezier_curve_t& other) const {
@@ -158,7 +172,7 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
     const bezier_curve_t* other_cast = dynamic_cast<const bezier_curve_t*>(&other);
     if(other_cast)
-      return (*this == *other_cast); // no isApprox between two bezier, only exact equality
+      return isApprox(*other_cast);
     else
       return curve_abc_t::isApprox(other,prec,order);
   }

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -155,12 +155,20 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
     return !(*this == other);
   }
 
+  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    const bezier_curve_t* other_cast = dynamic_cast<const bezier_curve_t*>(&other);
+    if(other_cast)
+      return (*this == *other_cast); // no isApprox between two bezier, only exact equality
+    else
+      return curve_abc_t::isApprox(other,prec,order);
+  }
+
   virtual bool operator==(const curve_abc_t& other) const {
-    return curve_abc_t::isApprox(other);
+      return isApprox(other);
   }
 
   virtual bool operator!=(const curve_abc_t& other) const {
-    return !curve_abc_t::isApprox(other);
+    return !(*this == other);
   }
 
 

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -39,7 +39,7 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   typedef std::vector<point_t, Eigen::aligned_allocator<point_t> > t_point_t;
   typedef typename t_point_t::const_iterator cit_point_t;
   typedef bezier_curve<Time, Numeric, Safe, Point> bezier_curve_t;
-  typedef piecewise_curve<Time, Numeric, Safe, point_t, t_point_t, bezier_curve_t> piecewise_bezier_curve_t;
+  typedef piecewise_curve<Time, Numeric, Safe, point_t> piecewise_curve_t;
   typedef curve_abc<Time, Numeric, Safe, point_t> curve_abc_t;  // parent class
 
   /* Constructors - destructors */
@@ -325,12 +325,12 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   }
 
   /// \brief Split the bezier curve in several curves, all accessible
-  /// within a piecewise_bezier_curve_t.
+  /// within a piecewise_curve_t.
   /// \param times : list of times of size n.
-  /// \return a piecewise_bezier_curve_t comprising n+1 curves
+  /// \return a piecewise_curve_t comprising n+1 curves
   ///
-  piecewise_bezier_curve_t split(const vector_x_t& times) const {
-    typename piecewise_bezier_curve_t::t_curve_t curves;
+  piecewise_curve_t split(const vector_x_t& times) const {
+    typename piecewise_curve_t::t_curve_t curves;
     bezier_curve_t current = *this;
     for (int i = 0; i < times.rows(); ++i) {
       std::pair<bezier_curve_t, bezier_curve_t> pairsplit = current.split(times[i]);
@@ -338,7 +338,7 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
       current = pairsplit.second;
     }
     curves.push_back(current);
-    return piecewise_bezier_curve_t(curves);
+    return piecewise_curve_t(curves);
   }
 
   /// \brief Extract a bezier curve defined between \f$[t_1,t_2]\f$ from the actual bezier curve

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -39,6 +39,7 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   typedef std::vector<point_t, Eigen::aligned_allocator<point_t> > t_point_t;
   typedef typename t_point_t::const_iterator cit_point_t;
   typedef bezier_curve<Time, Numeric, Safe, Point> bezier_curve_t;
+  typedef boost::shared_ptr<bezier_curve_t> bezier_curve_ptr_t;
   typedef piecewise_curve<Time, Numeric, Safe, point_t> piecewise_curve_t;
   typedef curve_abc<Time, Numeric, Safe, point_t> curve_abc_t;  // parent class
   typedef typename curve_abc_t::curve_ptr_t curve_ptr_t;
@@ -305,7 +306,7 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   /// \param u : unNormalized time.
   /// \return pair containing the first element of both bezier curve obtained.
   ///
-  std::pair<bezier_curve_t, bezier_curve_t> split(const Numeric t) const {
+  std::pair<bezier_curve_ptr_t, bezier_curve_ptr_t> split(const Numeric t) const {
     check_conditions();
     if (fabs(t - T_max_) < MARGIN) {
       throw std::runtime_error("can't split curve, interval range is equal to original curve");
@@ -322,8 +323,8 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
       wps_second[degree_ - id] = casteljau_pts.back();
       ++id;
     }
-    bezier_curve_t c_first(wps_first.begin(), wps_first.end(), T_min_, t, mult_T_);
-    bezier_curve_t c_second(wps_second.begin(), wps_second.end(), t, T_max_, mult_T_);
+    bezier_curve_ptr_t c_first(new bezier_curve_t(wps_first.begin(), wps_first.end(), T_min_, t, mult_T_));
+    bezier_curve_ptr_t c_second(new bezier_curve_t(wps_second.begin(), wps_second.end(), t, T_max_, mult_T_));
     return std::make_pair(c_first, c_second);
   }
 
@@ -333,10 +334,12 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   /// \return a piecewise_curve_t comprising n+1 curves
   ///
   piecewise_curve_t split(const vector_x_t& times) const {
-    typename piecewise_curve_t::t_curve_t curves;
-    bezier_curve_t current = *this;
-    for (int i = 0; i < times.rows(); ++i) {
-      std::pair<bezier_curve_t, bezier_curve_t> pairsplit = current.split(times[i]);
+    typename piecewise_curve_t::t_curve_ptr_t curves;
+    std::pair<bezier_curve_ptr_t, bezier_curve_ptr_t> pairsplit = split(times[0]);
+    curves.push_back(pairsplit.first);
+    bezier_curve_ptr_t  current = pairsplit.second;
+    for (int i = 1; i < times.rows(); ++i) {
+      pairsplit = current->split(times[i]);
       curves.push_back(pairsplit.first);
       current = pairsplit.second;
     }

--- a/include/curves/cubic_hermite_spline.h
+++ b/include/curves/cubic_hermite_spline.h
@@ -39,6 +39,7 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
   typedef std::vector<Time> vector_time_t;
   typedef Numeric num_t;
   typedef curve_abc<Time, Numeric, Safe, point_t> curve_abc_t;  // parent class
+  typedef cubic_hermite_spline<Time, Numeric, Safe, point_t> cubic_hermite_spline_t;
 
 
  public:
@@ -112,7 +113,7 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
     return evalCubicHermiteSpline(t, order);
   }
 
-  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t /*order*/) const {
+  cubic_hermite_spline_t* compute_derivate(const std::size_t /*order*/) const {
     throw std::logic_error("Compute derivate for cubic hermite spline is not implemented yet.");
   }
 

--- a/include/curves/cubic_hermite_spline.h
+++ b/include/curves/cubic_hermite_spline.h
@@ -103,6 +103,53 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
     }
   }
 
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const cubic_hermite_spline_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    //std::cout<<"is approx in hermite called."<<std::endl;
+    (void)order; // silent warning, order is not used in this class.
+    bool equal =  T_min_ == other.min()
+        && T_max_ == other.max()
+        && dim_ == other.dim()
+        && degree_ == other.degree()
+        && size_ == other.size()
+        && time_control_points_ == other.time_control_points_
+        && duration_splines_ == other.duration_splines_;
+    if(!equal)
+      return false;
+    for (std::size_t i = 0 ; i < size_ ;++i)
+    {
+      if((!control_points_[i].first.isApprox(other.control_points_[i].first,prec)) ||
+         (!control_points_[i].second.isApprox(other.control_points_[i].second,prec)) )
+        return false;
+    }
+    return true;
+  }
+
+  virtual bool operator==(const cubic_hermite_spline_t& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const cubic_hermite_spline_t& other) const {
+    return !(*this == other);
+  }
+
+  virtual bool operator==(const curve_abc_t& other) const {
+    return curve_abc_t::isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_abc_t& other) const {
+    return !curve_abc_t::isApprox(other);
+  }
+
+
   ///  \brief Evaluate the derivative of order N of spline at time t.
   ///  \param t : time when to evaluate the spline.
   ///  \param order : order of derivative.

--- a/include/curves/cubic_hermite_spline.h
+++ b/include/curves/cubic_hermite_spline.h
@@ -141,12 +141,20 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
     return !(*this == other);
   }
 
+  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    const cubic_hermite_spline_t* other_cast = dynamic_cast<const cubic_hermite_spline_t*>(&other);
+    if(other_cast)
+      return isApprox(*other_cast);
+    else
+      return curve_abc_t::isApprox(other,prec,order);
+  }
+
   virtual bool operator==(const curve_abc_t& other) const {
-    return curve_abc_t::isApprox(other);
+    return isApprox(other);
   }
 
   virtual bool operator!=(const curve_abc_t& other) const {
-    return !curve_abc_t::isApprox(other);
+    return !(*this == other);
   }
 
 

--- a/include/curves/cubic_hermite_spline.h
+++ b/include/curves/cubic_hermite_spline.h
@@ -112,6 +112,11 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
     return evalCubicHermiteSpline(t, order);
   }
 
+  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t order) const {
+    throw std::logic_error("Compute derivate for cubic hermite spline is not implemented yet.");
+  }
+
+
   /// \brief Set time of each control point of cubic hermite spline.
   /// Set duration of each spline, Exemple : \f$( 0., 0.5, 0.9, ..., 4.5 )\f$ with
   /// values corresponding to times for \f$P_0, P_1, P_2, ..., P_N\f$ respectively.<br>

--- a/include/curves/cubic_hermite_spline.h
+++ b/include/curves/cubic_hermite_spline.h
@@ -112,7 +112,7 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
     return evalCubicHermiteSpline(t, order);
   }
 
-  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t order) const {
+  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t /*order*/) const {
     throw std::logic_error("Compute derivate for cubic hermite spline is not implemented yet.");
   }
 

--- a/include/curves/cubic_hermite_spline.h
+++ b/include/curves/cubic_hermite_spline.h
@@ -325,6 +325,9 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
   /// \brief Get the maximum time for which the curve is defined.
   /// \return \f$t_{max}\f$, upper bound of time range.
   Time virtual max() const { return time_control_points_.back(); }
+  /// \brief Get the degree of the curve.
+  /// \return \f$degree\f$, the degree of the curve.
+  virtual std::size_t  degree() const {return degree_;}
   /*Helpers*/
 
   /*Attributes*/

--- a/include/curves/curve_abc.h
+++ b/include/curves/curve_abc.h
@@ -59,10 +59,50 @@ struct curve_abc : std::unary_function<Time, Point>, public serialization::Seria
   /// \return \f$\frac{d^Nx(t)}{dt^N}\f$, point corresponding on derivative curve of order N at time t.
   virtual point_derivate_t derivate(const time_t t, const std::size_t order) const = 0;
 
-  ///  \brief Compute the derived curve at order N.
-  ///  \param order : order of derivative.
-  ///  \return \f$\frac{d^Nx(t)}{dt^N}\f$ derivative order N of the curve.
-  //virtual curve_t* compute_derivate(const std::size_t order) const = 0 ;
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    bool equal = (min() == other.min())
+               && (max() == other.max())
+               && (dim() == other.dim());
+    if(!equal){
+      return false;
+    }
+    // check the value along the two curves
+    Numeric t = min();
+    while(t<= max()){
+      if(!(*this)(t).isApprox(other(t),prec)){
+        return false;
+      }
+      t += 0.01; // FIXME : define this step somewhere ??
+    }
+    //  check if the derivatives are equals
+    for(size_t n = 1 ; n <= order ; ++n){
+      t = min();
+      while(t<= max()){
+        if(!derivate(t,n).isApprox(other.derivate(t,n),prec)){
+          return false;
+        }
+        t += 0.01; // FIXME : define this step somewhere ??
+      }
+    }
+    return true;
+  }
+
+  virtual bool operator==(const curve_t& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_t& other) const {
+    return !(*this == other);
+  }
 
   /*Operations*/
 

--- a/include/curves/curve_abc.h
+++ b/include/curves/curve_abc.h
@@ -51,7 +51,7 @@ struct curve_abc : std::unary_function<Time, Point>, public serialization::Seria
   ///  \brief Compute the derived curve at order N.
   ///  \param order : order of derivative.
   ///  \return \f$\frac{d^Nx(t)}{dt^N}\f$ derivative order N of the curve.
-  virtual curve_ptr_t compute_derivate(const std::size_t order) const = 0;
+  virtual curve_t* compute_derivate(const std::size_t order) const = 0;
 
   /// \brief Evaluate the derivative of order N of curve at time t.
   /// \param t : time when to evaluate the spline.

--- a/include/curves/curve_abc.h
+++ b/include/curves/curve_abc.h
@@ -70,6 +70,10 @@ struct curve_abc : std::unary_function<Time, Point>, public serialization::Seria
   /// \brief Get the maximum time for which the curve is defined.
   /// \return \f$t_{max}\f$, upper bound of time range.
   virtual time_t max() const = 0;
+  /// \brief Get the degree of the curve.
+  /// \return \f$degree\f$, the degree of the curve.
+  virtual std::size_t  degree() const =0;
+
   std::pair<time_t, time_t> timeRange() { return std::make_pair(min(), max()); }
   /*Helpers*/
 

--- a/include/curves/curve_abc.h
+++ b/include/curves/curve_abc.h
@@ -15,6 +15,7 @@
 #include "serialization/archive.hpp"
 #include "serialization/eigen-matrix.hpp"
 #include <boost/serialization/shared_ptr.hpp>
+#include <boost/smart_ptr/shared_ptr.hpp>
 
 #include <functional>
 
@@ -28,6 +29,8 @@ struct curve_abc : std::unary_function<Time, Point>, public serialization::Seria
   typedef Point point_t;
   typedef Point_derivate point_derivate_t;
   typedef Time time_t;
+  typedef curve_abc<Time, Numeric, Safe, point_t,point_derivate_t> curve_t; // parent class
+  typedef boost::shared_ptr<curve_t> curve_ptr_t;
 
   /* Constructors - destructors */
  public:
@@ -49,6 +52,11 @@ struct curve_abc : std::unary_function<Time, Point>, public serialization::Seria
   /// \param order : order of derivative.
   /// \return \f$\frac{d^Nx(t)}{dt^N}\f$, point corresponding on derivative curve of order N at time t.
   virtual point_derivate_t derivate(const time_t t, const std::size_t order) const = 0;
+
+  ///  \brief Compute the derived curve at order N.
+  ///  \param order : order of derivative.
+  ///  \return \f$\frac{d^Nx(t)}{dt^N}\f$ derivative order N of the curve.
+  //virtual curve_t* compute_derivate(const std::size_t order) const = 0 ;
 
   /*Operations*/
 

--- a/include/curves/curve_abc.h
+++ b/include/curves/curve_abc.h
@@ -47,6 +47,12 @@ struct curve_abc : std::unary_function<Time, Point>, public serialization::Seria
   ///  \return \f$x(t)\f$, point corresponding on curve at time t.
   virtual point_t operator()(const time_t t) const = 0;
 
+
+  ///  \brief Compute the derived curve at order N.
+  ///  \param order : order of derivative.
+  ///  \return \f$\frac{d^Nx(t)}{dt^N}\f$ derivative order N of the curve.
+  virtual curve_ptr_t compute_derivate(const std::size_t order) const = 0;
+
   /// \brief Evaluate the derivative of order N of curve at time t.
   /// \param t : time when to evaluate the spline.
   /// \param order : order of derivative.

--- a/include/curves/curve_conversion.h
+++ b/include/curves/curve_conversion.h
@@ -16,40 +16,40 @@ namespace curves {
 /// \brief Converts a cubic hermite spline or a bezier curve to a polynomial.
 /// \param curve   : the bezier curve/cubic hermite spline defined between [Tmin,Tmax] to convert.
 /// \return the equivalent polynomial.
-template <typename Polynomial, typename curveTypeToConvert>
-Polynomial polynomial_from_curve(const curveTypeToConvert& curve) {
+template <typename Polynomial>
+Polynomial polynomial_from_curve(const typename Polynomial::curve_abc_t& curve) {
   typedef typename Polynomial::t_point_t t_point_t;
   typedef typename Polynomial::num_t num_t;
   t_point_t coefficients;
-  curveTypeToConvert current(curve);
   coefficients.push_back(curve(curve.min()));
   num_t T = curve.max() - curve.min();
   num_t T_div = 1.0;
   num_t fact = 1;
-  for (std::size_t i = 1; i <= curve.degree_; ++i) {
+  for (std::size_t i = 1; i <= curve.degree(); ++i) {
     fact *= (num_t)i;
-    coefficients.push_back(current.derivate(current.min(), i) / fact);
+    coefficients.push_back(curve.derivate(curve.min(), i) / fact);
   }
+
+
   return Polynomial(coefficients, curve.min(), curve.max());
 }
 
 /// \brief Converts a cubic hermite spline or polynomial of order 3 or less to a cubic bezier curve.
 /// \param curve   : the polynomial of order 3 or less/cubic hermite spline defined between [Tmin,Tmax] to convert.
 /// \return the equivalent cubic bezier curve.
-template <typename Bezier, typename curveTypeToConvert>
-Bezier bezier_from_curve(const curveTypeToConvert& curve) {
+template <typename Bezier>
+Bezier bezier_from_curve(const typename Bezier::curve_abc_t& curve) {
   typedef typename Bezier::point_t point_t;
   typedef typename Bezier::t_point_t t_point_t;
   typedef typename Bezier::num_t num_t;
-  curveTypeToConvert current(curve);
-  num_t T_min = current.min();
-  num_t T_max = current.max();
+  num_t T_min = curve.min();
+  num_t T_max = curve.max();
   num_t T = T_max - T_min;
   // Positions and derivatives
-  point_t p0 = current(T_min);
-  point_t p1 = current(T_max);
-  point_t m0 = current.derivate(T_min, 1);
-  point_t m1 = current.derivate(T_max, 1);
+  point_t p0 = curve(T_min);
+  point_t p1 = curve(T_max);
+  point_t m0 = curve.derivate(T_min, 1);
+  point_t m1 = curve.derivate(T_max, 1);
   // Convert to bezier control points
   // for t in [Tmin,Tmax] and T=Tmax-Tmin : x'(0)=3(b_p1-b_p0)/T and x'(1)=3(b_p3-b_p2)/T
   // so : m0=3(b_p1-b_p0)/T and m1=3(b_p3-b_p2)/T
@@ -63,27 +63,26 @@ Bezier bezier_from_curve(const curveTypeToConvert& curve) {
   control_points.push_back(b_p1);
   control_points.push_back(b_p2);
   control_points.push_back(b_p3);
-  return Bezier(control_points.begin(), control_points.end(), current.min(), current.max());
+  return Bezier(control_points.begin(), control_points.end(), curve.min(), curve.max());
 }
 
 /// \brief Converts a polynomial of order 3 or less/cubic bezier curve to a cubic hermite spline.
 /// \param curve   : the polynomial of order 3 or less/cubic bezier curve defined between [Tmin,Tmax] to convert.
 /// \return the equivalent cubic hermite spline.
-template <typename Hermite, typename curveTypeToConvert>
-Hermite hermite_from_curve(const curveTypeToConvert& curve) {
+template <typename Hermite>
+Hermite hermite_from_curve(const typename Hermite::curve_abc_t& curve) {
   typedef typename Hermite::pair_point_tangent_t pair_point_tangent_t;
   typedef typename Hermite::t_pair_point_tangent_t t_pair_point_tangent_t;
   typedef typename Hermite::point_t point_t;
   typedef typename Hermite::num_t num_t;
-  curveTypeToConvert current(curve);
-  num_t T_min = current.min();
-  num_t T_max = current.max();
+  num_t T_min = curve.min();
+  num_t T_max = curve.max();
   num_t T = T_max - T_min;
   // Positions and derivatives
-  point_t p0 = current(T_min);
-  point_t p1 = current(T_max);
-  point_t m0 = current.derivate(T_min, 1);
-  point_t m1 = current.derivate(T_max, 1);
+  point_t p0 = curve(T_min);
+  point_t p1 = curve(T_max);
+  point_t m0 = curve.derivate(T_min, 1);
+  point_t m1 = curve.derivate(T_max, 1);
   // Create pairs pos/vel
   pair_point_tangent_t pair0(p0, m0);
   pair_point_tangent_t pair1(p1, m1);

--- a/include/curves/exact_cubic.h
+++ b/include/curves/exact_cubic.h
@@ -39,7 +39,7 @@ template <typename Time = double, typename Numeric = Time, bool Safe = false,
           typename Point = Eigen::Matrix<Numeric, Eigen::Dynamic, 1>,
           typename T_Point = std::vector<Point, Eigen::aligned_allocator<Point> >,
           typename SplineBase = polynomial<Time, Numeric, Safe, Point, T_Point> >
-struct exact_cubic : public piecewise_curve<Time, Numeric, Safe, Point, T_Point, SplineBase> {
+struct exact_cubic : public piecewise_curve<Time, Numeric, Safe, Point> {
   typedef Point point_t;
   typedef T_Point t_point_t;
   typedef Eigen::Matrix<Numeric, Eigen::Dynamic, Eigen::Dynamic> MatrixX;
@@ -53,8 +53,8 @@ struct exact_cubic : public piecewise_curve<Time, Numeric, Safe, Point, T_Point,
   typedef curve_constraints<Point> spline_constraints;
 
   typedef exact_cubic<Time, Numeric, Safe, Point, T_Point, SplineBase> exact_cubic_t;
-  typedef piecewise_curve<Time, Numeric, Safe, Point, T_Point, SplineBase> piecewise_curve_t;
   typedef curve_abc<Time, Numeric, Safe, point_t> curve_abc_t;  // parent class
+  typedef piecewise_curve<Time, Numeric, Safe, Point> piecewise_curve_t;
 
   /* Constructors - destructors */
  public:

--- a/include/curves/exact_cubic.h
+++ b/include/curves/exact_cubic.h
@@ -55,6 +55,7 @@ struct exact_cubic : public piecewise_curve<Time, Numeric, Safe, Point> {
   typedef exact_cubic<Time, Numeric, Safe, Point, T_Point, SplineBase> exact_cubic_t;
   typedef curve_abc<Time, Numeric, Safe, point_t> curve_abc_t;  // parent class
   typedef piecewise_curve<Time, Numeric, Safe, Point> piecewise_curve_t;
+  typedef typename piecewise_curve_t::t_curve_ptr_t t_curve_ptr_t;
 
   /* Constructors - destructors */
  public:
@@ -68,7 +69,13 @@ struct exact_cubic : public piecewise_curve<Time, Numeric, Safe, Point> {
   ///
   template <typename In>
   exact_cubic(In wayPointsBegin, In wayPointsEnd)
-      : piecewise_curve_t(computeWayPoints<In>(wayPointsBegin, wayPointsEnd)) {}
+      : piecewise_curve_t()
+  {
+    t_spline_t subSplines = computeWayPoints<In>(wayPointsBegin, wayPointsEnd);
+    for (cit_spline_t it = subSplines.begin() ; it != subSplines.end() ; ++it){
+      this->add_curve(*it);
+    }
+  }
 
   /// \brief Constructor.
   /// \param wayPointsBegin : an iterator pointing to the first element of a waypoint container.
@@ -77,11 +84,24 @@ struct exact_cubic : public piecewise_curve<Time, Numeric, Safe, Point> {
   ///
   template <typename In>
   exact_cubic(In wayPointsBegin, In wayPointsEnd, const spline_constraints& constraints)
-      : piecewise_curve_t(computeWayPoints<In>(wayPointsBegin, wayPointsEnd, constraints)) {}
+      : piecewise_curve_t()
+  {
+    t_spline_t subSplines = computeWayPoints<In>(wayPointsBegin, wayPointsEnd,constraints);
+    for (cit_spline_t it = subSplines.begin() ; it != subSplines.end() ; ++it){
+      this->add_curve(*it);
+    }
+  }
 
   /// \brief Constructor.
   /// \param subSplines: vector of subSplines.
-  exact_cubic(const t_spline_t& subSplines) : piecewise_curve_t(subSplines) {}
+  exact_cubic(const t_spline_t& subSplines) : piecewise_curve_t()
+  {
+    for (cit_spline_t it = subSplines.begin() ; it != subSplines.end() ; ++it){
+      this->add_curve(*it);
+    }
+  }
+
+  exact_cubic(const t_curve_ptr_t& subSplines) : piecewise_curve_t(subSplines)  { }
 
   /// \brief Copy Constructor.
   exact_cubic(const exact_cubic& other) : piecewise_curve_t(other) {}
@@ -91,7 +111,13 @@ struct exact_cubic : public piecewise_curve<Time, Numeric, Safe, Point> {
 
   std::size_t getNumberSplines() { return this->getNumberCurves(); }
 
-  spline_t getSplineAt(std::size_t index) { return this->curves_.at(index); }
+  spline_t getSplineAt(std::size_t index) {
+    boost::shared_ptr<spline_t> s_ptr = boost::dynamic_pointer_cast<spline_t>(this->curves_.at(index));
+    if(s_ptr)
+      return *s_ptr;
+    else
+      throw std::runtime_error("Parent piecewise curve do not contain only curves created from exact_cubic class methods");
+  }
 
  private:
   /// \brief Compute polynom of exact cubic spline from waypoints.

--- a/include/curves/fwd.h
+++ b/include/curves/fwd.h
@@ -21,12 +21,12 @@ template <typename Time, typename Numeric, bool Safe,typename Point >
 template <typename Time, typename Numeric, bool Safe,typename Point >
   struct cubic_hermite_spline;
 
-template <typename Time, typename Numeric, bool Safe, typename Point ,
-            typename T_Point , typename SplineBase >
+template <typename Time, typename Numeric, bool Safe, typename Point,
+          typename T_Point,typename SplineBase >
   struct exact_cubic;
 
 template <typename Time, typename Numeric, bool Safe, typename Point,
-            typename T_Point, typename Curve, typename Point_derivate>
+            typename Point_derivate>
   struct piecewise_curve;
 
 template <typename Time, typename Numeric, bool Safe,typename Point, typename T_Point>

--- a/include/curves/fwd.h
+++ b/include/curves/fwd.h
@@ -54,29 +54,47 @@ template <typename Numeric>
   struct quadratic_variable;
 
 // typedef of the commonly used templates arguments :
-
+// eigen types :
 typedef Eigen::Vector3d point3_t;
 typedef Eigen::Matrix<double, 6, 1> point6_t;
 typedef Eigen::VectorXd pointX_t;
 typedef Eigen::Matrix<double, 3, 3> matrix3_t;
+typedef Eigen::Matrix<double, 4, 4> matrix4_t;
 typedef Eigen::Quaternion<double> quaternion_t;
 typedef Eigen::Transform<double, 3, Eigen::Affine> transform_t;
+typedef std::vector<pointX_t, Eigen::aligned_allocator<point3_t> > t_point3_t;
 typedef std::vector<pointX_t, Eigen::aligned_allocator<pointX_t> > t_pointX_t;
+
+// abstract curves types:
 typedef curve_abc<double, double, true, pointX_t,pointX_t> curve_abc_t; // base abstract class
+typedef curve_abc<double, double, true, point3_t,point3_t> curve_3_t;    // generic class of curve of size 3
 typedef curve_abc<double, double, true, matrix3_t, point3_t> curve_rotation_t;  // templated class used for the rotation (return dimension are fixed)
+typedef curve_abc<double, double, true, transform_t, point6_t> curve_SE3_t;  // templated abstract class used for all the se3 curves (return dimension are fixed)
+
+// shared pointer to abstract types:
 typedef boost::shared_ptr<curve_abc_t> curve_ptr_t;
+typedef boost::shared_ptr<curve_3_t> curve3_ptr_t;
 typedef boost::shared_ptr<curve_rotation_t> curve_rotation_ptr_t;
+typedef boost::shared_ptr<curve_SE3_t> curve_SE3_ptr_t;
+
+// definition of all curves class with pointX as return type:
 typedef polynomial<double, double, true, pointX_t, t_pointX_t> polynomial_t;
-typedef exact_cubic<double, double, true, pointX_t,
-  std::vector<pointX_t, Eigen::aligned_allocator<pointX_t> >, polynomial_t> exact_cubic_t;
-typedef bezier_curve<double, double, true, pointX_t> bezier_curve_t;
+typedef exact_cubic<double, double, true, pointX_t,t_pointX_t, polynomial_t> exact_cubic_t;
+typedef bezier_curve<double, double, true, pointX_t> bezier_t;
+typedef cubic_hermite_spline<double, double, true, pointX_t> cubic_hermite_spline_t;
+typedef piecewise_curve <double, double, true, pointX_t,pointX_t> piecewise_t;
+
+// definition of all curves class with point3 as return type:
+typedef polynomial<double, double, true, point3_t, t_point3_t> polynomial3_t;
+typedef exact_cubic<double, double, true, point3_t,t_point3_t, polynomial_t> exact_cubic3_t;
+typedef bezier_curve<double, double, true, point3_t> bezier3_t;
+typedef cubic_hermite_spline<double, double, true, point3_t> cubic_hermite_spline3_t;
+typedef piecewise_curve <double, double, true, point3_t,point3_t> piecewise3_t;
+
+// special curves with return type fixed:
 typedef SO3Linear<double, double, true> SO3Linear_t;
 typedef SE3Curve<double, double, true> SE3Curve_t;
-typedef curve_abc<double, double, true, transform_t, point6_t> curve_SE3_t;  // templated abstract class used for all the se3 curves (return dimension are fixed)
-typedef boost::shared_ptr<curve_SE3_t> curve_SE3_ptr_t;
-typedef cubic_hermite_spline<double, double, true, pointX_t> cubic_hermite_spline_t;
-typedef piecewise_curve <double, double, true, pointX_t,pointX_t> piecewise_curve_t;
-typedef piecewise_curve <double, double, true,  transform_t, point6_t> piecewise_SE3_curve_t;
+typedef piecewise_curve <double, double, true,  transform_t, point6_t> piecewise_SE3_t;
 
 }
 

--- a/include/curves/fwd.h
+++ b/include/curves/fwd.h
@@ -9,6 +9,9 @@
 
 #ifndef CURVES_FWD_H
 #define CURVES_FWD_H
+#include <Eigen/Dense>
+#include <vector>
+#include <boost/smart_ptr/shared_ptr.hpp>
 
 namespace curves {
 
@@ -49,6 +52,32 @@ template <typename Numeric, bool Safe>
 
 template <typename Numeric>
   struct quadratic_variable;
+
+// typedef of the commonly used templates arguments :
+
+typedef Eigen::Vector3d point3_t;
+typedef Eigen::Matrix<double, 6, 1> point6_t;
+typedef Eigen::VectorXd pointX_t;
+typedef Eigen::Matrix<double, 3, 3> matrix3_t;
+typedef Eigen::Quaternion<double> quaternion_t;
+typedef Eigen::Transform<double, 3, Eigen::Affine> transform_t;
+typedef std::vector<pointX_t, Eigen::aligned_allocator<pointX_t> > t_pointX_t;
+typedef curve_abc<double, double, true, pointX_t,pointX_t> curve_abc_t; // base abstract class
+typedef curve_abc<double, double, true, matrix3_t, point3_t> curve_rotation_t;  // templated class used for the rotation (return dimension are fixed)
+typedef boost::shared_ptr<curve_abc_t> curve_ptr_t;
+typedef boost::shared_ptr<curve_rotation_t> curve_rotation_ptr_t;
+typedef polynomial<double, double, true, pointX_t, t_pointX_t> polynomial_t;
+typedef exact_cubic<double, double, true, pointX_t,
+  std::vector<pointX_t, Eigen::aligned_allocator<pointX_t> >, polynomial_t> exact_cubic_t;
+typedef bezier_curve<double, double, true, pointX_t> bezier_curve_t;
+typedef SO3Linear<double, double, true> SO3Linear_t;
+typedef SE3Curve<double, double, true> SE3Curve_t;
+typedef curve_abc<double, double, true, transform_t, point6_t> curve_SE3_t;  // templated abstract class used for all the se3 curves (return dimension are fixed)
+typedef boost::shared_ptr<curve_SE3_t> curve_SE3_ptr_t;
+typedef cubic_hermite_spline<double, double, true, pointX_t> cubic_hermite_spline_t;
+typedef piecewise_curve <double, double, true, pointX_t,pointX_t> piecewise_curve_t;
+typedef piecewise_curve <double, double, true,  transform_t, point6_t> piecewise_SE3_curve_t;
+
 }
 
 #endif // CURVES_FWD_H

--- a/include/curves/helpers/effector_spline.h
+++ b/include/curves/helpers/effector_spline.h
@@ -102,9 +102,8 @@ exact_cubic_t* effector_spline(In wayPointsBegin, In wayPointsEnd, const Point& 
   spline_t end_spline =
       make_end_spline(land_normal, landWaypoint.second, land_offset, landWaypoint.first, land_offset_duration);
   spline_constraints_t constraints = compute_required_offset_velocity_acceleration(end_spline, land_offset_duration);
-  exact_cubic_t all_but_end(waypoints.begin(), waypoints.end(), constraints);
-  t_spline_t splines = all_but_end.curves_;
-  splines.push_back(end_spline);
+  exact_cubic_t splines(waypoints.begin(), waypoints.end(), constraints);
+  splines.add_curve(end_spline);
   return new exact_cubic_t(splines);
 }
 }  // namespace helpers

--- a/include/curves/helpers/effector_spline_rotation.h
+++ b/include/curves/helpers/effector_spline_rotation.h
@@ -76,7 +76,7 @@ class rotation_spline : public curve_abc_quat_t {
     throw std::runtime_error("TODO quaternion spline does not implement derivate");
   }
 
-  boost::shared_ptr<curve_abc_quat_t> compute_derivate(const std::size_t /*order*/) const {
+  curve_abc_quat_t* compute_derivate(const std::size_t /*order*/) const {
     throw std::logic_error("Compute derivate for quaternion spline is not implemented yet.");
   }
 

--- a/include/curves/helpers/effector_spline_rotation.h
+++ b/include/curves/helpers/effector_spline_rotation.h
@@ -87,6 +87,9 @@ class rotation_spline : public curve_abc_quat_t {
   virtual std::size_t dim() const { return dim_; }
   virtual time_t min() const { return min_; }
   virtual time_t max() const { return max_; }
+  /// \brief Get the degree of the curve.
+  /// \return \f$degree\f$, the degree of the curve.
+  virtual std::size_t  degree() const {return 1;}
 
   /*Attributes*/
   Eigen::Quaterniond quat_from_;                 // const

--- a/include/curves/helpers/effector_spline_rotation.h
+++ b/include/curves/helpers/effector_spline_rotation.h
@@ -76,7 +76,7 @@ class rotation_spline : public curve_abc_quat_t {
     throw std::runtime_error("TODO quaternion spline does not implement derivate");
   }
 
-  boost::shared_ptr<curve_abc_quat_t> compute_derivate(const std::size_t order) const {
+  boost::shared_ptr<curve_abc_quat_t> compute_derivate(const std::size_t /*order*/) const {
     throw std::logic_error("Compute derivate for quaternion spline is not implemented yet.");
   }
 

--- a/include/curves/helpers/effector_spline_rotation.h
+++ b/include/curves/helpers/effector_spline_rotation.h
@@ -76,6 +76,10 @@ class rotation_spline : public curve_abc_quat_t {
     throw std::runtime_error("TODO quaternion spline does not implement derivate");
   }
 
+  boost::shared_ptr<curve_abc_quat_t> compute_derivate(const std::size_t order) const {
+    throw std::logic_error("Compute derivate for quaternion spline is not implemented yet.");
+  }
+
   /// \brief Initialize time reparametrization for spline.
   exact_cubic_constraint_one_dim computeWayPoints() const {
     t_waypoint_one_dim_t waypoints;

--- a/include/curves/linear_variable.h
+++ b/include/curves/linear_variable.h
@@ -81,7 +81,7 @@ struct linear_variable : public serialization::Serializable {
 
   Numeric norm() const { return isZero() ? 0 : (B_.norm() + c_.norm()); }
 
-  bool isApprox(const linear_variable_t& other,const double prec = Eigen::NumTraits<Numeric>::dummy_precision()){
+  bool isApprox(const linear_variable_t& other,const double prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
     return (*this - other).norm() < prec;
   }
 

--- a/include/curves/optimization/integral_cost.h
+++ b/include/curves/optimization/integral_cost.h
@@ -32,8 +32,8 @@ quadratic_variable<Numeric> compute_integral_cost_internal(const problem_data<Po
   typedef bezier_curve<Numeric, Numeric, true, linear_variable<Numeric> > bezier_t;
   typedef typename bezier_t::t_point_t t_point_t;
   typedef typename t_point_t::const_iterator cit_point_t;
-  bezier_t acc = pData.bezier->compute_derivate(num_derivate);
-  const t_point_t& wps = acc.waypoints();
+  boost::shared_ptr<bezier_t> acc = boost::dynamic_pointer_cast<bezier_t>(pData.bezier->compute_derivate(num_derivate));
+  const t_point_t& wps = acc->waypoints();
   return bezier_product<Point, Numeric, cit_point_t>(wps.begin(), wps.end(), wps.begin(), wps.end(), pData.dim_);
 }
 

--- a/include/curves/optimization/integral_cost.h
+++ b/include/curves/optimization/integral_cost.h
@@ -32,9 +32,11 @@ quadratic_variable<Numeric> compute_integral_cost_internal(const problem_data<Po
   typedef bezier_curve<Numeric, Numeric, true, linear_variable<Numeric> > bezier_t;
   typedef typename bezier_t::t_point_t t_point_t;
   typedef typename t_point_t::const_iterator cit_point_t;
-  boost::shared_ptr<bezier_t> acc = boost::dynamic_pointer_cast<bezier_t>(pData.bezier->compute_derivate(num_derivate));
+  bezier_t* acc = pData.bezier->compute_derivate(num_derivate);
   const t_point_t& wps = acc->waypoints();
-  return bezier_product<Point, Numeric, cit_point_t>(wps.begin(), wps.end(), wps.begin(), wps.end(), pData.dim_);
+  quadratic_variable<Numeric> res(bezier_product<Point, Numeric, cit_point_t>(wps.begin(), wps.end(), wps.begin(), wps.end(), pData.dim_));
+  delete acc;
+  return res;
 }
 
 template <typename Point, typename Numeric>

--- a/include/curves/piecewise_curve.h
+++ b/include/curves/piecewise_curve.h
@@ -202,7 +202,7 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point,Point_deriv
     piecewise_curve_t pc_res;
     // Convert and add all other curves (segments)
     for (std::size_t i = 0; i < size_; i++) {
-      pc_res.add_curve(bezier_from_curve<Bezier, curve_ptr_t>(curves_.at(i)));
+      pc_res.add_curve(bezier_from_curve<Bezier>(*curves_.at(i)));
     }
     return pc_res;
   }
@@ -217,7 +217,7 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point,Point_deriv
     piecewise_curve_t pc_res;
     // Convert and add all other curves (segments)
     for (std::size_t i = 0; i < size_; i++) {
-      pc_res.add_curve(hermite_from_curve<Hermite, curve_ptr_t>(curves_.at(i)));
+      pc_res.add_curve(hermite_from_curve<Hermite>(*curves_.at(i)));
     }
     return pc_res;
   }
@@ -232,7 +232,7 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point,Point_deriv
     piecewise_curve_t pc_res;
     // Convert and add all other curves (segments)
     for (std::size_t i = 0; i < size_; i++) {
-      pc_res.add_curve(polynomial_from_curve<Polynomial, curve_ptr_t>(curves_.at(i)));
+      pc_res.add_curve(polynomial_from_curve<Polynomial>(*curves_.at(i)));
     }
     return pc_res;
   }

--- a/include/curves/piecewise_curve.h
+++ b/include/curves/piecewise_curve.h
@@ -183,9 +183,9 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point,Point_deriv
 
   std::size_t num_curves() const { return curves_.size(); }
 
-  const curve_t& curve_at_time(const time_t t) const { return curves_[find_interval(t)]; }
+  const curve_ptr_t& curve_at_time(const time_t t) const { return curves_[find_interval(t)]; }
 
-  const curve_t& curve_at_index(const std::size_t idx) const {
+  const curve_ptr_t& curve_at_index(const std::size_t idx) const {
     if (Safe && idx >= num_curves()) {
       throw std::length_error(
           "curve_at_index: requested index greater than number of curves in piecewise_curve instance");

--- a/include/curves/piecewise_curve.h
+++ b/include/curves/piecewise_curve.h
@@ -11,6 +11,7 @@
 #include "curve_abc.h"
 #include "curve_conversion.h"
 #include <boost/smart_ptr/shared_ptr.hpp>
+#include <boost/serialization/vector.hpp>
 
 namespace curves {
 /// \class PiecewiseCurve.
@@ -400,12 +401,9 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point,Point_deriv
     if (version) {
       // Do something depending on version ?
     }
-    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(curve_abc_t);
+    ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(curve_t);
     ar& boost::serialization::make_nvp("dim", dim_);
-    //ar& boost::serialization::make_nvp("curves", curves_);
-    for(typename t_curve_ptr_t::const_iterator it = curves_.begin() ; it != curves_.end() ; ++it){
-      ar& *(*it); // how does it work when deserializing ??
-    }
+    ar& boost::serialization::make_nvp("curves", curves_);
     ar& boost::serialization::make_nvp("time_curves", time_curves_);
     ar& boost::serialization::make_nvp("size", size_);
     ar& boost::serialization::make_nvp("T_min", T_min_);

--- a/include/curves/piecewise_curve.h
+++ b/include/curves/piecewise_curve.h
@@ -98,10 +98,11 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point,Point_deriv
    * @param order order of derivative
    * @return
    */
-  curve_ptr_t compute_derivate(const std::size_t order) const {
-    boost::shared_ptr<piecewise_curve_t> res(new piecewise_curve_t());
+  piecewise_curve_t* compute_derivate(const std::size_t order) const {
+    piecewise_curve_t* res(new piecewise_curve_t());
     for (typename t_curve_ptr_t::const_iterator itc = curves_.begin(); itc < curves_.end(); ++itc) {
-      res->add_curve_ptr((*itc)->compute_derivate(order));
+      curve_ptr_t ptr((*itc)->compute_derivate(order));
+      res->add_curve_ptr(ptr);
     }
     return res;
   }

--- a/include/curves/piecewise_curve.h
+++ b/include/curves/piecewise_curve.h
@@ -98,13 +98,13 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point,Point_deriv
    * @param order order of derivative
    * @return
    */
-//  piecewise_curve_t compute_derivate(const std::size_t order) const {
-//    piecewise_curve_t res;
-//    for (typename t_curve_ptr_t::const_iterator itc = curves_.begin(); itc < curves_.end(); ++itc) {
-//      res.add_curve((*itc)->compute_derivate(order));
-//    }
-//    return res;
-//  }
+  curve_ptr_t compute_derivate(const std::size_t order) const {
+    boost::shared_ptr<piecewise_curve_t> res(new piecewise_curve_t());
+    for (typename t_curve_ptr_t::const_iterator itc = curves_.begin(); itc < curves_.end(); ++itc) {
+      res->add_curve_ptr((*itc)->compute_derivate(order));
+    }
+    return res;
+  }
 
 
   template <typename Curve>

--- a/include/curves/piecewise_curve.h
+++ b/include/curves/piecewise_curve.h
@@ -375,6 +375,11 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point,Point_deriv
   /// \brief Get the maximum time for which the curve is defined.
   /// \return \f$t_{max}\f$, upper bound of time range.
   Time virtual max() const { return T_max_; }
+  /// \brief Get the degree of the curve.
+  /// \return \f$degree\f$, the degree of the curve.
+  virtual std::size_t  degree() const {
+    throw std::runtime_error("degree() method is not implemented for this type of curve.");
+  }
   std::size_t getNumberCurves() { return curves_.size(); }
   /*Helpers*/
 

--- a/include/curves/polynomial.h
+++ b/include/curves/polynomial.h
@@ -254,6 +254,42 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
     return h;
   }
 
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const polynomial_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    //std::cout<<"is approx in polynomial called."<<std::endl;
+    (void)order; // silent warning, order is not used in this class.
+    return T_min_ == other.min()
+        && T_max_ == other.max()
+        && dim_ == other.dim()
+        && degree_ == other.degree()
+        && coefficients_.isApprox(other.coefficients_,prec);
+  }
+
+  virtual bool operator==(const polynomial_t& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const polynomial_t& other) const {
+    return !(*this == other);
+  }
+
+  virtual bool operator==(const curve_abc_t& other) const {
+    return curve_abc_t::isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_abc_t& other) const {
+    return !curve_abc_t::isApprox(other);
+  }
+
+
   ///  \brief Evaluation of the derivative of order N of spline at time t.
   ///  \param t : the time when to evaluate the spline.
   ///  \param order : order of derivative.

--- a/include/curves/polynomial.h
+++ b/include/curves/polynomial.h
@@ -329,6 +329,9 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
   /// \brief Get the maximum time for which the curve is defined.
   /// \return \f$t_{max}\f$ upper bound of time range.
   num_t virtual max() const { return T_max_; }
+  /// \brief Get the degree of the curve.
+  /// \return \f$degree\f$, the degree of the curve.
+  virtual std::size_t  degree() const {return degree_;}
   /*Helpers*/
 
   /*Attributes*/

--- a/include/curves/polynomial.h
+++ b/include/curves/polynomial.h
@@ -41,6 +41,7 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
   typedef Eigen::MatrixXd coeff_t;
   typedef Eigen::Ref<coeff_t> coeff_t_ref;
   typedef polynomial<Time, Numeric, Safe, Point, T_Point> polynomial_t;
+  typedef typename curve_abc_t::curve_ptr_t curve_ptr_t;
 
   /* Constructors - destructors */
  public:
@@ -272,14 +273,16 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
     return currentPoint_;
   }
 
-  polynomial_t compute_derivate(const std::size_t order) const {
+  curve_ptr_t compute_derivate(const std::size_t order) const {
     check_if_not_empty();
-    if (order == 0) {
-      return *this;
-    }
+    if(order < 1)
+      throw std::invalid_argument("ORDER argument for compute_derivate must be >= 1 .");
     coeff_t coeff_derivated = deriv_coeff(coefficients_);
-    polynomial_t deriv(coeff_derivated, T_min_, T_max_);
-    return deriv.compute_derivate(order - 1);
+    curve_ptr_t deriv(new polynomial_t(coeff_derivated, T_min_, T_max_));
+    if(order == 1)
+      return deriv;
+    else
+      return deriv->compute_derivate(order - 1);
   }
 
   Eigen::MatrixXd coeff() const { return coefficients_; }

--- a/include/curves/polynomial.h
+++ b/include/curves/polynomial.h
@@ -281,12 +281,20 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
     return !(*this == other);
   }
 
+  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    const polynomial_t* other_cast = dynamic_cast<const polynomial_t*>(&other);
+    if(other_cast)
+      return isApprox(*other_cast);
+    else
+      return curve_abc_t::isApprox(other,prec,order);
+  }
+
   virtual bool operator==(const curve_abc_t& other) const {
-    return curve_abc_t::isApprox(other);
+    return isApprox(other);
   }
 
   virtual bool operator!=(const curve_abc_t& other) const {
-    return !curve_abc_t::isApprox(other);
+    return !(*this == other);
   }
 
 

--- a/include/curves/polynomial.h
+++ b/include/curves/polynomial.h
@@ -273,16 +273,15 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
     return currentPoint_;
   }
 
-  curve_ptr_t compute_derivate(const std::size_t order) const {
+  polynomial_t* compute_derivate(const std::size_t order) const {
     check_if_not_empty();
-    if(order < 1)
-      throw std::invalid_argument("ORDER argument for compute_derivate must be >= 1 .");
+    if (order == 0) {
+      return new polynomial_t(*this);
+    }
     coeff_t coeff_derivated = deriv_coeff(coefficients_);
-    curve_ptr_t deriv(new polynomial_t(coeff_derivated, T_min_, T_max_));
-    if(order == 1)
-      return deriv;
-    else
-      return deriv->compute_derivate(order - 1);
+    polynomial_t deriv(coeff_derivated, T_min_, T_max_);
+    return deriv.compute_derivate(order - 1);
+
   }
 
   Eigen::MatrixXd coeff() const { return coefficients_; }

--- a/include/curves/se3_curve.h
+++ b/include/curves/se3_curve.h
@@ -174,6 +174,9 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
   /// \brief Get the maximum time for which the curve is defined.
   /// \return \f$t_{max}\f$ upper bound of time range.
   time_t max() const { return T_max_; }
+  /// \brief Get the degree of the curve.
+  /// \return \f$degree\f$, the degree of the curve.
+  virtual std::size_t  degree() const {return translation_curve_->degree();}
   /*Helpers*/
 
   /*Attributes*/

--- a/include/curves/se3_curve.h
+++ b/include/curves/se3_curve.h
@@ -164,7 +164,7 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
     return res;
   }
 
-  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t /*order*/) const {
+  SE3Curve_t* compute_derivate(const std::size_t /*order*/) const {
     throw std::logic_error("Compute derivate for SE3 is not implemented yet.");
   }
 

--- a/include/curves/se3_curve.h
+++ b/include/curves/se3_curve.h
@@ -176,12 +176,19 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
     return !(*this == other);
   }
 
+  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    const SE3Curve_t* other_cast = dynamic_cast<const SE3Curve_t*>(&other);
+    if(other_cast)
+      return isApprox(*other_cast);
+    else
+      return curve_abc_t::isApprox(other,prec,order);
+  }
   virtual bool operator==(const curve_abc_t& other) const {
-    return curve_abc_t::isApprox(other);
+    return isApprox(other);
   }
 
   virtual bool operator!=(const curve_abc_t& other) const {
-    return !curve_abc_t::isApprox(other);
+    return !(*this == other);
   }
 
 

--- a/include/curves/se3_curve.h
+++ b/include/curves/se3_curve.h
@@ -164,7 +164,7 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
     return res;
   }
 
-  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t order) const {
+  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t /*order*/) const {
     throw std::logic_error("Compute derivate for SE3 is not implemented yet.");
   }
 

--- a/include/curves/se3_curve.h
+++ b/include/curves/se3_curve.h
@@ -164,6 +164,10 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
     return res;
   }
 
+  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t order) const {
+    throw std::logic_error("Compute derivate for SE3 is not implemented yet.");
+  }
+
   /*Helpers*/
   /// \brief Get dimension of curve.
   /// \return dimension of curve.

--- a/include/curves/se3_curve.h
+++ b/include/curves/se3_curve.h
@@ -150,6 +150,41 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
     return res;
   }
 
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const SE3Curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    //std::cout<<"is approx in SE3 called."<<std::endl;
+    (void)order; // silent warning, order is not used in this class.
+    return T_min_ == other.min()
+        && T_max_ == other.max()
+        && (translation_curve_ == other.translation_curve_ || translation_curve_->isApprox(*other.translation_curve_,prec))
+        && (rotation_curve_ == other.rotation_curve_ || rotation_curve_->isApprox(*other.rotation_curve_,prec));
+  }
+
+  virtual bool operator==(const SE3Curve_t& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const SE3Curve_t& other) const {
+    return !(*this == other);
+  }
+
+  virtual bool operator==(const curve_abc_t& other) const {
+    return curve_abc_t::isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_abc_t& other) const {
+    return !curve_abc_t::isApprox(other);
+  }
+
+
   ///  \brief Evaluation of the derivative of order N of spline at time t.
   ///  \param t : the time when to evaluate the spline.
   ///  \param order : order of derivative.

--- a/include/curves/serialization/registeration.hpp
+++ b/include/curves/serialization/registeration.hpp
@@ -31,18 +31,15 @@ namespace serialization {
     typedef std::vector<pointX_t, Eigen::aligned_allocator<pointX_t> > t_point_t;
 
     //register derived class
-    ar.template register_type<bezier_curve<Scalar, Scalar, true, pointX_t> >();
-    ar.template register_type<cubic_hermite_spline<Scalar, Scalar, true, pointX_t> >();
-    ar.template register_type<exact_cubic<Scalar, Scalar, true, pointX_t,
-        t_point_t, polynomial<Scalar, Scalar, true, pointX_t,t_point_t> > >();
-    ar.template register_type<piecewise_curve<Scalar, Scalar, true, pointX_t,
-        t_point_t, polynomial<Scalar, Scalar, true, pointX_t, t_point_t> ,pointX_t> >();
-    ar.template register_type<piecewise_curve<Scalar, Scalar, true, pointX_t,
-        t_point_t, bezier_curve<Scalar, Scalar, true, pointX_t> ,pointX_t> >();
-    ar.template register_type<piecewise_curve<Scalar, Scalar, true, pointX_t,
-        t_point_t, cubic_hermite_spline<Scalar, Scalar, true, pointX_t> ,pointX_t> >();
-    ar.template register_type<polynomial<Scalar, Scalar, true, pointX_t, t_point_t> >();
-    ar.template register_type<SO3Linear<Scalar, Scalar, true> >();
+    ar.template register_type<polynomial_t >();
+    ar.template register_type<exact_cubic_t >();
+    ar.template register_type<bezier_curve_t >();
+    ar.template register_type<SO3Linear_t >();
+    ar.template register_type<SE3Curve_t >();
+    ar.template register_type<cubic_hermite_spline_t >();
+    ar.template register_type<piecewise_curve_t >();
+    ar.template register_type<piecewise_SE3_curve_t >();
+
   }
 
 }

--- a/include/curves/serialization/registeration.hpp
+++ b/include/curves/serialization/registeration.hpp
@@ -30,12 +30,17 @@ namespace serialization {
     //register derived class
     ar.template register_type<polynomial_t >();
     ar.template register_type<exact_cubic_t >();
-    ar.template register_type<bezier_curve_t >();
+    ar.template register_type<bezier_t >();
+    ar.template register_type<cubic_hermite_spline_t >();
+    ar.template register_type<piecewise_t >();
+    ar.template register_type<polynomial3_t >();
+    ar.template register_type<exact_cubic3_t >();
+    ar.template register_type<bezier3_t >();
+    ar.template register_type<cubic_hermite_spline3_t >();
+    ar.template register_type<piecewise3_t >();
     ar.template register_type<SO3Linear_t >();
     ar.template register_type<SE3Curve_t >();
-    ar.template register_type<cubic_hermite_spline_t >();
-    ar.template register_type<piecewise_curve_t >();
-    ar.template register_type<piecewise_SE3_curve_t >();
+    ar.template register_type<piecewise_SE3_t >();
 
   }
 

--- a/include/curves/serialization/registeration.hpp
+++ b/include/curves/serialization/registeration.hpp
@@ -26,9 +26,6 @@ namespace serialization {
 
   template <class Archive>
   void register_types(Archive& ar){
-    typedef double Scalar;
-    typedef Eigen::Matrix<Scalar, -1, 1> pointX_t;
-    typedef std::vector<pointX_t, Eigen::aligned_allocator<pointX_t> > t_point_t;
 
     //register derived class
     ar.template register_type<polynomial_t >();

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -135,6 +135,9 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
   /// \brief Get the maximum time for which the curve is defined.
   /// \return \f$t_{max}\f$ upper bound of time range.
   time_t max() const { return T_max_; }
+  /// \brief Get the degree of the curve.
+  /// \return \f$degree\f$, the degree of the curve.
+  virtual std::size_t  degree() const {return 1;}
   matrix3_t getInitRotation()const {return init_rot_.toRotationMatrix();}
   matrix3_t getEndRotation()const {return end_rot_.toRotationMatrix();}
   matrix3_t getInitRotation() {return init_rot_.toRotationMatrix();}

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -125,6 +125,10 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
     }
   }
 
+  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t order) const {
+    throw std::logic_error("Compute derivate for SO3Linear is not implemented yet.");
+  }
+
   /*Helpers*/
   /// \brief Get dimension of curve.
   /// \return dimension of curve.

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -125,7 +125,7 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
     }
   }
 
-  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t /*order*/) const {
+  SO3Linear_t* compute_derivate(const std::size_t /*order*/) const {
     throw std::logic_error("Compute derivate for SO3Linear is not implemented yet.");
   }
 

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -125,7 +125,7 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
     }
   }
 
-  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t order) const {
+  boost::shared_ptr<curve_abc_t> compute_derivate(const std::size_t /*order*/) const {
     throw std::logic_error("Compute derivate for SO3Linear is not implemented yet.");
   }
 

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -107,6 +107,42 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
   ///  \return \f$x(t)\f$ point corresponding on spline at time t.
   virtual matrix3_t operator()(const time_t t) const { return computeAsQuaternion(t).toRotationMatrix(); }
 
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const SO3Linear_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    //std::cout<<"is approx in SO3 called."<<std::endl;
+    (void)order; // silent warning, order is not used in this class.
+    return  T_min_ == other.min()
+        && T_max_ == other.max()
+        && dim_ == other.dim()
+        && init_rot_.isApprox(other.init_rot_,prec)
+        && end_rot_.isApprox(other.end_rot_,prec);
+  }
+
+  virtual bool operator==(const SO3Linear_t& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const SO3Linear_t& other) const {
+    return !(*this == other);
+  }
+
+  virtual bool operator==(const curve_abc_t& other) const {
+    return curve_abc_t::isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_abc_t& other) const {
+    return !curve_abc_t::isApprox(other);
+  }
+
+
   ///  \brief Evaluation of the derivative of order N of spline at time t.
   ///  \param t : the time when to evaluate the spline.
   ///  \param order : order of derivative.

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -122,8 +122,8 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
     return  T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()
-        && init_rot_.isApprox(other.init_rot_,prec)
-        && end_rot_.isApprox(other.end_rot_,prec);
+        && init_rot_.toRotationMatrix().isApprox(other.init_rot_.toRotationMatrix(),prec)
+        && end_rot_.toRotationMatrix().isApprox(other.end_rot_.toRotationMatrix(),prec);
   }
 
   virtual bool operator==(const SO3Linear_t& other) const {

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -134,12 +134,20 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
     return !(*this == other);
   }
 
+  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    const SO3Linear_t* other_cast = dynamic_cast<const SO3Linear_t*>(&other);
+    if(other_cast)
+      return isApprox(*other_cast);
+    else
+      return curve_abc_t::isApprox(other,prec,order);
+  }
+
   virtual bool operator==(const curve_abc_t& other) const {
-    return curve_abc_t::isApprox(other);
+    return isApprox(other);
   }
 
   virtual bool operator!=(const curve_abc_t& other) const {
-    return !curve_abc_t::isApprox(other);
+    return !(*this == other);
   }
 
 

--- a/python/curves_python.cpp
+++ b/python/curves_python.cpp
@@ -400,6 +400,8 @@ BOOST_PYTHON_MODULE(curves) {
   class_<CurveWrapper, boost::noncopyable>("curve", no_init)
       .def("__call__", pure_virtual(&curve_abc_t::operator()), "Evaluate the curve at the given time.",
            args("self", "t"))
+      .def("__eq__", &curve_abc_t::operator==)
+      .def("__ne__", &curve_abc_t::operator!=)
       .def("derivate", pure_virtual(&curve_abc_t::derivate), "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_abc_t::compute_derivate),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
@@ -422,6 +424,8 @@ BOOST_PYTHON_MODULE(curves) {
   class_<Curve3Wrapper, boost::noncopyable, bases<curve_abc_t> >("curve3", no_init)
       .def("__call__", pure_virtual(&curve_3_t::operator()), "Evaluate the curve at the given time.",
            args("self", "t"))
+      .def("__eq__", &curve_3_t::operator==)
+      .def("__ne__", &curve_3_t::operator!=)
       .def("derivate", pure_virtual(&curve_3_t::derivate), "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_3_t::compute_derivate),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
@@ -432,6 +436,8 @@ BOOST_PYTHON_MODULE(curves) {
   class_<CurveRotationWrapper, boost::noncopyable, bases<curve_abc_t> >("curve_rotation", no_init)
       .def("__call__", pure_virtual(&curve_rotation_t::operator()), "Evaluate the curve at the given time.",
            args("self", "t"))
+      .def("__eq__", &curve_rotation_t::operator==)
+      .def("__ne__", &curve_rotation_t::operator!=)
       .def("derivate", pure_virtual(&curve_rotation_t::derivate),
            "Evaluate the derivative of order N of curve at time t.", args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_rotation_t::compute_derivate),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
@@ -442,6 +448,8 @@ BOOST_PYTHON_MODULE(curves) {
   class_<CurveSE3Wrapper, boost::noncopyable, bases<curve_abc_t> >("curve_SE3", no_init)
       .def("__call__", &se3Return, "Evaluate the curve at the given time. Return as an homogeneous matrix.",
            args("self", "t"))
+      .def("__eq__", &curve_SE3_t::operator==)
+      .def("__ne__", &curve_SE3_t::operator!=)
       .def("derivate", pure_virtual(&curve_SE3_t::derivate),
            "Evaluate the derivative of order N of curve at time t. Return as a vector 6.", args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_rotation_t::compute_derivate),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))

--- a/python/curves_python.cpp
+++ b/python/curves_python.cpp
@@ -136,53 +136,42 @@ polynomial_t* wrapPolynomialConstructorFromBoundaryConditionsDegree3(const point
 }
 polynomial_t* wrapPolynomialConstructorFromBoundaryConditionsDegree5(const pointX_t& init, const pointX_t& d_init,
                                                                      const pointX_t& dd_init, const pointX_t& end,
-                                                                     const point_t& d_end, const point_t& dd_end,
+                                                                     const pointX_t& d_end, const pointX_t& dd_end,
                                                                      const real min, const real max) {
   return new polynomial_t(init, d_init, dd_init, end, d_end, dd_end, min, max);
 }
 /* End wrap polynomial */
 
 /* Wrap piecewise curve */
-piecewise_polynomial_curve_t* wrapPiecewisePolynomialCurveConstructor(const polynomial_t& pol) {
-  return new piecewise_polynomial_curve_t(pol);
+piecewise_t* wrapPiecewiseCurveConstructor(const curve_ptr_t& curve) {
+  return new piecewise_t(curve);
 }
-piecewise_polynomial_curve_t* wrapPiecewisePolynomialCurveEmptyConstructor() {
-  return new piecewise_polynomial_curve_t();
+piecewise_t* wrapPiecewisePolynomialCurveEmptyConstructor() {
+  return new piecewise_t();
 }
-piecewise_bezier_curve_t* wrapPiecewiseBezierCurveConstructor(const bezier_t& bc) {
-  return new piecewise_bezier_curve_t(bc);
+piecewise_SE3_t* wrapPiecewiseSE3Constructor(const curve_SE3_ptr_t& curve) {
+  return new piecewise_SE3_t(curve);
 }
-piecewise_bezier_linear_curve_t* wrapPiecewiseLinearBezierCurveConstructor(const bezier_linear_variable_t& bc) {
-  return new piecewise_bezier_linear_curve_t(bc);
-}
-piecewise_cubic_hermite_curve_t* wrapPiecewiseCubicHermiteCurveConstructor(const cubic_hermite_spline_t& ch) {
-  return new piecewise_cubic_hermite_curve_t(ch);
+piecewise_SE3_t* wrapPiecewiseSE3EmptyConstructor() {
+  return new piecewise_SE3_t();
 }
 
-piecewise_SE3_curve_t* wrapPiecewiseSE3Constructor(const SE3Curve_t& curve) {
-  return new piecewise_SE3_curve_t(curve);
-}
-
-piecewise_SE3_curve_t* wrapPiecewiseSE3EmptyConstructor() {
-  return new piecewise_SE3_curve_t();
-}
-static piecewise_polynomial_curve_t discretPointToPolynomialC0(const pointX_list_t& points,
+static piecewise_t discretPointToPolynomialC0(const pointX_list_t& points,
                                                                const time_waypoints_t& time_points) {
   t_pointX_t points_list = vectorFromEigenArray<pointX_list_t, t_pointX_t>(points);
   t_time_t time_points_list = vectorFromEigenVector<time_waypoints_t, t_time_t>(time_points);
-  return piecewise_polynomial_curve_t::convert_discrete_points_to_polynomial<polynomial_t>(points_list,
-                                                                                           time_points_list);
+  return piecewise_t::convert_discrete_points_to_polynomial<polynomial_t>(points_list,time_points_list);
 }
-static piecewise_polynomial_curve_t discretPointToPolynomialC1(const pointX_list_t& points,
+static piecewise_t discretPointToPolynomialC1(const pointX_list_t& points,
                                                                const pointX_list_t& points_derivative,
                                                                const time_waypoints_t& time_points) {
   t_pointX_t points_list = vectorFromEigenArray<pointX_list_t, t_pointX_t>(points);
   t_pointX_t points_derivative_list = vectorFromEigenArray<pointX_list_t, t_pointX_t>(points_derivative);
   t_time_t time_points_list = vectorFromEigenVector<time_waypoints_t, t_time_t>(time_points);
-  return piecewise_polynomial_curve_t::convert_discrete_points_to_polynomial<polynomial_t>(
+  return piecewise_t::convert_discrete_points_to_polynomial<polynomial_t>(
       points_list, points_derivative_list, time_points_list);
 }
-static piecewise_polynomial_curve_t discretPointToPolynomialC2(const pointX_list_t& points,
+static piecewise_t discretPointToPolynomialC2(const pointX_list_t& points,
                                                                const pointX_list_t& points_derivative,
                                                                const pointX_list_t& points_second_derivative,
                                                                const time_waypoints_t& time_points) {
@@ -191,20 +180,21 @@ static piecewise_polynomial_curve_t discretPointToPolynomialC2(const pointX_list
   t_pointX_t points_second_derivative_list = vectorFromEigenArray<pointX_list_t, t_pointX_t>(points_second_derivative);
 
   t_time_t time_points_list = vectorFromEigenVector<time_waypoints_t, t_time_t>(time_points);
-  return piecewise_polynomial_curve_t::convert_discrete_points_to_polynomial<polynomial_t>(
+  return piecewise_t::convert_discrete_points_to_polynomial<polynomial_t>(
       points_list, points_derivative_list, points_second_derivative_list, time_points_list);
 }
-void addFinalPointC0(piecewise_polynomial_curve_t& self, const pointX_t& end, const real time) {
+
+void addFinalPointC0(piecewise_t& self, const pointX_t& end, const real time) {
   if(self.num_curves() == 0)
     throw std::runtime_error("Piecewise append : you need to add at least one curve before using append(finalPoint) method.");
   if (self.is_continuous(1) && self.num_curves()>1 )
     std::cout << "Warning: by adding this final point to the piecewise curve, you loose C1 continuity and only "
                  "guarantee C0 continuity."
               << std::endl;
-  polynomial_t pol(self(self.max()), end, self.max(), time);
-  self.add_curve(pol);
+  curve_ptr_t pol(new polynomial_t(self(self.max()), end, self.max(), time));
+  self.add_curve_ptr(pol);
 }
-void addFinalPointC1(piecewise_polynomial_curve_t& self, const pointX_t& end, const pointX_t& d_end, const real time) {
+void addFinalPointC1(piecewise_t& self, const pointX_t& end, const pointX_t& d_end, const real time) {
   if(self.num_curves() == 0)
     throw std::runtime_error("Piecewise append : you need to add at least one curve before using append(finalPoint) method.");
   if (self.is_continuous(2) && self.num_curves()>1 )
@@ -212,10 +202,10 @@ void addFinalPointC1(piecewise_polynomial_curve_t& self, const pointX_t& end, co
                  "guarantee C1 continuity."
               << std::endl;
   if (!self.is_continuous(1)) std::cout << "Warning: the current piecewise curve is not C1 continuous." << std::endl;
-  polynomial_t pol(self(self.max()), self.derivate(self.max(), 1), end, d_end, self.max(), time);
-  self.add_curve(pol);
+  curve_ptr_t pol(new polynomial_t(self(self.max()), self.derivate(self.max(), 1), end, d_end, self.max(), time));
+  self.add_curve_ptr(pol);
 }
-void addFinalPointC2(piecewise_polynomial_curve_t& self, const pointX_t& end, const pointX_t& d_end,
+void addFinalPointC2(piecewise_t& self, const pointX_t& end, const pointX_t& d_end,
                      const pointX_t& dd_end, const real time) {
   if(self.num_curves() == 0)
     throw std::runtime_error("Piecewise append : you need to add at least one curve before using append(finalPoint) method.");
@@ -224,9 +214,9 @@ void addFinalPointC2(piecewise_polynomial_curve_t& self, const pointX_t& end, co
                  "guarantee C2 continuity."
               << std::endl;
   if (!self.is_continuous(2)) std::cout << "Warning: the current piecewise curve is not C2 continuous." << std::endl;
-  polynomial_t pol(self(self.max()), self.derivate(self.max(), 1), self.derivate(self.max(), 2), end, d_end, dd_end,
-                   self.max(), time);
-  self.add_curve(pol);
+  curve_ptr_t pol(new polynomial_t(self(self.max()), self.derivate(self.max(), 1), self.derivate(self.max(), 2), end, d_end, dd_end,
+                   self.max(), time));
+  self.add_curve_ptr(pol);
 }
 
 /* end wrap piecewise polynomial curve */
@@ -280,8 +270,8 @@ bezier_t* bezier_linear_variable_t_evaluate(const bezier_linear_variable_t* b, c
   return new bezier_t(evaluateLinear<bezier_t, bezier_linear_variable_t>(*b, x));
 }
 
-bezier_t::piecewise_bezier_curve_t (bezier_t::*splitspe)(const bezier_t::vector_x_t&) const = &bezier_t::split;
-bezier_linear_variable_t::piecewise_bezier_curve_t (bezier_linear_variable_t::*split_py)(
+bezier_t::piecewise_curve_t (bezier_t::*splitspe)(const bezier_t::vector_x_t&) const = &bezier_t::split;
+bezier_linear_variable_t::piecewise_curve_t (bezier_linear_variable_t::*split_py)(
     const bezier_linear_variable_t::vector_x_t&) const = &bezier_linear_variable_t::split;
 
 /* End wrap exact cubic spline */
@@ -359,13 +349,13 @@ pointX_t se3returnTranslation(const SE3Curve_t& curve, const real t) { return po
 typedef pinocchio::SE3Tpl<real, 0> SE3_t;
 typedef pinocchio::MotionTpl<real, 0> Motion_t;
 
-SE3_t piecewiseSE3ReturnPinocchio(const piecewise_SE3_curve_t& curve, const real t) { return SE3_t(curve(t).matrix()); }
+SE3_t piecewiseSE3ReturnPinocchio(const piecewise_SE3_t& curve, const real t) { return SE3_t(curve(t).matrix()); }
 
-Motion_t piecewiseSE3ReturnDerivatePinocchio(const piecewise_SE3_curve_t& curve, const real t, const std::size_t order) {
+Motion_t piecewiseSE3ReturnDerivatePinocchio(const piecewise_SE3_t& curve, const real t, const std::size_t order) {
   return Motion_t(curve.derivate(t, order));
 }
 
-void addFinalSE3(piecewise_SE3_curve_t& self, const SE3_t& end, const real time) {
+void addFinalSE3(piecewise_SE3_t& self, const SE3_t& end, const real time) {
   if(self.num_curves() == 0)
     throw std::runtime_error("Piecewise append : you need to add at least one curve before using append(finalPoint) method.");
   if (self.is_continuous(1) && self.num_curves()>1 )
@@ -378,14 +368,14 @@ void addFinalSE3(piecewise_SE3_curve_t& self, const SE3_t& end, const real time)
 
 #endif  // CURVES_WITH_PINOCCHIO_SUPPORT
 
-matrix4_t piecewiseSE3Return(const piecewise_SE3_curve_t& curve, const real t) { return curve(t).matrix(); }
+matrix4_t piecewiseSE3Return(const piecewise_SE3_t& curve, const real t) { return curve(t).matrix(); }
 
 
-matrix3_t piecewiseSE3returnRotation(const piecewise_SE3_curve_t& curve, const real t) { return curve(t).rotation(); }
+matrix3_t piecewiseSE3returnRotation(const piecewise_SE3_t& curve, const real t) { return curve(t).rotation(); }
 
-pointX_t piecewiseSE3returnTranslation(const piecewise_SE3_curve_t& curve, const real t) { return pointX_t(curve(t).translation()); }
+pointX_t piecewiseSE3returnTranslation(const piecewise_SE3_t& curve, const real t) { return pointX_t(curve(t).translation()); }
 
-void addFinalTransform(piecewise_SE3_curve_t& self, const matrix4_t& end, const real time) {
+void addFinalTransform(piecewise_SE3_t& self, const matrix4_t& end, const real time) {
   if(self.num_curves() == 0)
     throw std::runtime_error("Piecewise append : you need to add at least one curve before using append(finalPoint) method.");
   if (self.is_continuous(1) && self.num_curves()>1 )
@@ -406,7 +396,6 @@ BOOST_PYTHON_MODULE(curves) {
   eigenpy::enableEigenPySpecific<pointX_t, pointX_t>();
   eigenpy::enableEigenPySpecific<pointX_list_t, pointX_list_t>();
   eigenpy::enableEigenPySpecific<coeff_t, coeff_t>();
-  eigenpy::enableEigenPySpecific<point_list_t, point_list_t>();
   eigenpy::enableEigenPySpecific<matrix3_t, matrix3_t>();
   eigenpy::enableEigenPySpecific<matrix4_t, matrix4_t>();
   // eigenpy::enableEigenPySpecific<quaternion_t,quaternion_t>();
@@ -596,10 +585,10 @@ BOOST_PYTHON_MODULE(curves) {
 
   /** END polynomial function**/
   /** BEGIN piecewise curve function **/
-  class_<piecewise_polynomial_curve_t, bases<curve_abc_t> >("piecewise_polynomial_curve", init<>())
+  class_<piecewise_t, bases<curve_abc_t> >("piecewise", init<>())
       .def("__init__",
-           make_constructor(&wrapPiecewisePolynomialCurveConstructor, default_call_policies(), arg("curve")),
-           "Create a peicewise-polynomial curve containing the given polynomial curve.")
+           make_constructor(&wrapPiecewiseCurveConstructor, default_call_policies(), arg("curve")),
+           "Create a peicewise curve containing the given curve.")
       .def("FromPointsList", &discretPointToPolynomialC0,
            "Create a piecewise-polynomial connecting exactly all the given points at the given time. The created "
            "piecewise is C0 continuous.",
@@ -627,156 +616,80 @@ BOOST_PYTHON_MODULE(curves) {
            "and time and connecting exactly self(self.max()) and end. It guarantee C2 continuity and guarantee that "
            "self.derivate(time,1) == d_end and self.derivate(time,2) == dd_end",
            args("self", "end", "d_end", "d_end", "time"))
-      .def("compute_derivate", &piecewise_polynomial_curve_t::compute_derivate,
-           "Return a piecewise_polynomial curve which is the derivate of this.", args("self", "order"))
-      .def("append", &piecewise_polynomial_curve_t::add_curve,
+      .def("compute_derivate", &piecewise_t::compute_derivate,
+           "Return a piecewise curve which is the derivate of this.", args("self", "order"))
+      .def("append", &piecewise_t::add_curve_ptr,
            "Add a new curve to piecewise curve, which should be defined in T_{min},T_{max}] "
            "where T_{min} is equal toT_{max} of the actual piecewise curve.")
-      .def("is_continuous", &piecewise_polynomial_curve_t::is_continuous,
+      .def("is_continuous", &piecewise_t::is_continuous,
            "Check if the curve is continuous at the given order.",args("self,order"))
-      .def("convert_piecewise_curve_to_bezier",
-           &piecewise_polynomial_curve_t::convert_piecewise_curve_to_bezier<bezier_t>,
-           "Convert a piecewise polynomial curve to to a piecewise bezier curve")
-      .def("convert_piecewise_curve_to_cubic_hermite",
-           &piecewise_polynomial_curve_t::convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>,
-           "Convert a piecewise polynomial curve to to a piecewise cubic hermite spline")
-      .def("curve_at_index", &piecewise_polynomial_curve_t::curve_at_index,
-           return_value_policy<copy_const_reference>())
-      .def("curve_at_time", &piecewise_polynomial_curve_t::curve_at_time, return_value_policy<copy_const_reference>())
-      .def("num_curves", &piecewise_polynomial_curve_t::num_curves)
-      .def("saveAsText", &piecewise_polynomial_curve_t::saveAsText<piecewise_polynomial_curve_t>, bp::args("filename"),
-           "Saves *this inside a text file.")
-      .def("loadFromText", &piecewise_polynomial_curve_t::loadFromText<piecewise_polynomial_curve_t>,
-           bp::args("filename"), "Loads *this from a text file.")
-      .def("saveAsXML", &piecewise_polynomial_curve_t::saveAsXML<piecewise_polynomial_curve_t>,
-           bp::args("filename", "tag_name"), "Saves *this inside a XML file.")
-      .def("loadFromXML", &piecewise_polynomial_curve_t::loadFromXML<piecewise_polynomial_curve_t>,
-           bp::args("filename", "tag_name"), "Loads *this from a XML file.")
-      .def("saveAsBinary", &piecewise_polynomial_curve_t::saveAsBinary<piecewise_polynomial_curve_t>,
-           bp::args("filename"), "Saves *this inside a binary file.")
-      .def("loadFromBinary", &piecewise_polynomial_curve_t::loadFromBinary<piecewise_polynomial_curve_t>,
-           bp::args("filename"), "Loads *this from a binary file.");
-
-  class_<piecewise_bezier_curve_t, bases<curve_abc_t> >("piecewise_bezier_curve", init<>())
-      .def("__init__", make_constructor(&wrapPiecewiseBezierCurveConstructor))
-      .def("compute_derivate", &piecewise_polynomial_curve_t::compute_derivate,
-           "Return a piecewise_polynomial curve which is the derivate of this.", args("self", "order"))
-      .def("append", &piecewise_bezier_curve_t::add_curve)
-      .def("is_continuous", &piecewise_bezier_curve_t::is_continuous)
       .def("convert_piecewise_curve_to_polynomial",
-           &piecewise_bezier_curve_t::convert_piecewise_curve_to_polynomial<polynomial_t>,
-           "Convert a piecewise bezier curve to to a piecewise polynomial curve")
-      .def("convert_piecewise_curve_to_cubic_hermite",
-           &piecewise_bezier_curve_t::convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>,
-           "Convert a piecewise bezier curve to to a piecewise cubic hermite spline")
-      .def("curve_at_index", &piecewise_bezier_curve_t::curve_at_index, return_value_policy<copy_const_reference>())
-      .def("curve_at_time", &piecewise_bezier_curve_t::curve_at_time, return_value_policy<copy_const_reference>())
-      .def("num_curves", &piecewise_bezier_curve_t::num_curves)
-      .def("saveAsText", &piecewise_bezier_curve_t::saveAsText<piecewise_bezier_curve_t>, bp::args("filename"),
-           "Saves *this inside a text file.")
-      .def("loadFromText", &piecewise_bezier_curve_t::loadFromText<piecewise_bezier_curve_t>, bp::args("filename"),
-           "Loads *this from a text file.")
-      .def("saveAsXML", &piecewise_bezier_curve_t::saveAsXML<piecewise_bezier_curve_t>,
-           bp::args("filename", "tag_name"), "Saves *this inside a XML file.")
-      .def("loadFromXML", &piecewise_bezier_curve_t::loadFromXML<piecewise_bezier_curve_t>,
-           bp::args("filename", "tag_name"), "Loads *this from a XML file.")
-      .def("saveAsBinary", &piecewise_bezier_curve_t::saveAsBinary<piecewise_bezier_curve_t>, bp::args("filename"),
-           "Saves *this inside a binary file.")
-      .def("loadFromBinary", &piecewise_bezier_curve_t::loadFromBinary<piecewise_bezier_curve_t>, bp::args("filename"),
-           "Loads *this from a binary file.");
-
-  class_<piecewise_cubic_hermite_curve_t, bases<curve_abc_t> >("piecewise_cubic_hermite_curve", init<>())
-      .def("__init__", make_constructor(&wrapPiecewiseCubicHermiteCurveConstructor))
-      .def("append", &piecewise_cubic_hermite_curve_t::add_curve)
-      .def("is_continuous", &piecewise_cubic_hermite_curve_t::is_continuous)
-      .def("convert_piecewise_curve_to_polynomial",
-           &piecewise_cubic_hermite_curve_t::convert_piecewise_curve_to_polynomial<polynomial_t>,
-           "Convert a piecewise cubic hermite spline to to a piecewise polynomial curve")
+           &piecewise_t::convert_piecewise_curve_to_bezier<polynomial_t>,
+           "Convert a piecewise curve to to a piecewise polynomial curve")
       .def("convert_piecewise_curve_to_bezier",
-           &piecewise_cubic_hermite_curve_t::convert_piecewise_curve_to_bezier<bezier_t>,
-           "Convert a piecewise cubic hermite spline to to a piecewise bezier curve")
-      .def("curve_at_index", &piecewise_cubic_hermite_curve_t::curve_at_index,
+           &piecewise_t::convert_piecewise_curve_to_bezier<bezier_t>,
+           "Convert a piecewise curve to to a piecewise bezier curve")
+      .def("convert_piecewise_curve_to_cubic_hermite",
+           &piecewise_t::convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>,
+           "Convert a piecewise curve to to a piecewise cubic hermite spline")
+      .def("curve_at_index", &piecewise_t::curve_at_index,
            return_value_policy<copy_const_reference>())
-      .def("curve_at_time", &piecewise_cubic_hermite_curve_t::curve_at_time,
-           return_value_policy<copy_const_reference>())
-      .def("num_curves", &piecewise_cubic_hermite_curve_t::num_curves)
-      .def("saveAsText", &piecewise_cubic_hermite_curve_t::saveAsText<piecewise_cubic_hermite_curve_t>,
-           bp::args("filename"), "Saves *this inside a text file.")
-      .def("loadFromText", &piecewise_cubic_hermite_curve_t::loadFromText<piecewise_cubic_hermite_curve_t>,
+      .def("curve_at_time", &piecewise_t::curve_at_time, return_value_policy<copy_const_reference>())
+      .def("num_curves", &piecewise_t::num_curves)
+      .def("saveAsText", &piecewise_t::saveAsText<piecewise_t>, bp::args("filename"),
+           "Saves *this inside a text file.")
+      .def("loadFromText", &piecewise_t::loadFromText<piecewise_t>,
            bp::args("filename"), "Loads *this from a text file.")
-      .def("saveAsXML", &piecewise_cubic_hermite_curve_t::saveAsXML<piecewise_cubic_hermite_curve_t>,
+      .def("saveAsXML", &piecewise_t::saveAsXML<piecewise_t>,
            bp::args("filename", "tag_name"), "Saves *this inside a XML file.")
-      .def("loadFromXML", &piecewise_cubic_hermite_curve_t::loadFromXML<piecewise_cubic_hermite_curve_t>,
+      .def("loadFromXML", &piecewise_t::loadFromXML<piecewise_t>,
            bp::args("filename", "tag_name"), "Loads *this from a XML file.")
-      .def("saveAsBinary", &piecewise_cubic_hermite_curve_t::saveAsBinary<piecewise_cubic_hermite_curve_t>,
+      .def("saveAsBinary", &piecewise_t::saveAsBinary<piecewise_t>,
            bp::args("filename"), "Saves *this inside a binary file.")
-      .def("loadFromBinary", &piecewise_cubic_hermite_curve_t::loadFromBinary<piecewise_cubic_hermite_curve_t>,
+      .def("loadFromBinary", &piecewise_t::loadFromBinary<piecewise_t>,
            bp::args("filename"), "Loads *this from a binary file.");
 
-  class_<piecewise_bezier_linear_curve_t, bases<curve_abc_t> >("piecewise_bezier_linear_curve_t", init<>())
-      .def("__init__", make_constructor(&wrapPiecewiseLinearBezierCurveConstructor))
-      .def("append", &piecewise_bezier_linear_curve_t::add_curve)
-      .def("is_continuous", &piecewise_bezier_linear_curve_t::is_continuous,
-           "Check if the curve is continuous at the given order.")
-      .def("curve_at_index", &piecewise_bezier_linear_curve_t::curve_at_index,
-           return_value_policy<copy_const_reference>())
-      .def("curve_at_time", &piecewise_bezier_linear_curve_t::curve_at_time,
-           return_value_policy<copy_const_reference>())
-      .def("num_curves", &piecewise_bezier_linear_curve_t::num_curves)
-      .def("saveAsText", &piecewise_bezier_linear_curve_t::saveAsText<piecewise_bezier_linear_curve_t>,
-           bp::args("filename"), "Saves *this inside a text file.")
-      .def("loadFromText", &piecewise_bezier_linear_curve_t::loadFromText<piecewise_bezier_linear_curve_t>,
-           bp::args("filename"), "Loads *this from a text file.")
-      .def("saveAsXML", &piecewise_bezier_linear_curve_t::saveAsXML<piecewise_bezier_linear_curve_t>,
-           bp::args("filename", "tag_name"), "Saves *this inside a XML file.")
-      .def("loadFromXML", &piecewise_bezier_linear_curve_t::loadFromXML<piecewise_bezier_linear_curve_t>,
-           bp::args("filename", "tag_name"), "Loads *this from a XML file.")
-      .def("saveAsBinary", &piecewise_bezier_linear_curve_t::saveAsBinary<piecewise_bezier_linear_curve_t>,
-           bp::args("filename"), "Saves *this inside a binary file.")
-      .def("loadFromBinary", &piecewise_bezier_linear_curve_t::loadFromBinary<piecewise_bezier_linear_curve_t>,
-           bp::args("filename"), "Loads *this from a binary file.");
-
-class_<piecewise_SE3_curve_t, bases<curve_abc_t> >("piecewise_SE3_curve", init<>())
+  class_<piecewise_SE3_t, bases<curve_abc_t> >("piecewise_SE3", init<>())
       .def("__init__", make_constructor(&wrapPiecewiseSE3Constructor, default_call_policies(), arg("curve")),
       "Create a piecewise-se3 curve containing the given se3 curve.")
       .def("__init__", make_constructor(&wrapPiecewiseSE3EmptyConstructor),
       "Create an empty piecewise-se3 curve.")
-//      .def("compute_derivate", &piecewise_SE3_curve_t::compute_derivate,
-//           "Return a piecewise_polynomial curve which is the derivate of this.", args("self", "order"))
-      .def("append", &piecewise_SE3_curve_t::add_curve,
+      .def("compute_derivate", &piecewise_SE3_t::compute_derivate,
+           "Return a piecewise_polynomial curve which is the derivate of this.", args("self", "order"))
+      .def("append", &piecewise_SE3_t::add_curve_ptr,
            "Add a new curve to piecewise curve, which should be defined in T_{min},T_{max}] "
            "where T_{min} is equal toT_{max} of the actual piecewise curve.",
            args("self,curve"))
-      .def("is_continuous", &piecewise_SE3_curve_t::is_continuous, "Check if the curve is continuous at the given order.",args("self,order"))
-      .def("curve_at_index", &piecewise_SE3_curve_t::curve_at_index, return_value_policy<copy_const_reference>())
-      .def("curve_at_time", &piecewise_SE3_curve_t::curve_at_time, return_value_policy<copy_const_reference>())
-      .def("num_curves", &piecewise_SE3_curve_t::num_curves)
+      .def("is_continuous", &piecewise_SE3_t::is_continuous, "Check if the curve is continuous at the given order.",args("self,order"))
+      .def("curve_at_index", &piecewise_SE3_t::curve_at_index, return_value_policy<copy_const_reference>())
+      .def("curve_at_time", &piecewise_SE3_t::curve_at_time, return_value_policy<copy_const_reference>())
+      .def("num_curves", &piecewise_SE3_t::num_curves)
       .def("rotation", &piecewiseSE3returnRotation, "Output the rotation (as a 3x3 matrix) at the given time.",
            args("self", "t"))
       .def("translation", &piecewiseSE3returnTranslation, "Output the translation (as a vector 3) at the given time.",
            args("self", "t"))
       .def("__call__", &piecewiseSE3Return, "Evaluate the curve at the given time. Return as an homogeneous matrix",
            args("self", "t"))
-      .def("derivate", &piecewise_SE3_curve_t::derivate,
+      .def("derivate", &piecewise_SE3_t::derivate,
            "Evaluate the derivative of order N of curve at time t. Return as a vector 6", args("self", "t", "N"))
-      .def("min", &piecewise_SE3_curve_t::min, "Get the LOWER bound on interval definition of the curve.")
-      .def("max", &piecewise_SE3_curve_t::max, "Get the HIGHER bound on interval definition of the curve.")
-      .def("dim", &piecewise_SE3_curve_t::dim, "Get the dimension of the curve.")
+      .def("min", &piecewise_SE3_t::min, "Get the LOWER bound on interval definition of the curve.")
+      .def("max", &piecewise_SE3_t::max, "Get the HIGHER bound on interval definition of the curve.")
+      .def("dim", &piecewise_SE3_t::dim, "Get the dimension of the curve.")
       .def("append", &addFinalTransform,
        "Append a new linear SE3 curve at the end of the piecewise curve, defined between self.max() "
        "and time and connecting exactly self(self.max()) and end",
        args("self", "end", "time"))
-      .def("saveAsText", &piecewise_SE3_curve_t::saveAsText<piecewise_SE3_curve_t>, bp::args("filename"),
+      .def("saveAsText", &piecewise_SE3_t::saveAsText<piecewise_SE3_t>, bp::args("filename"),
            "Saves *this inside a text file.")
-      .def("loadFromText", &piecewise_SE3_curve_t::loadFromText<piecewise_SE3_curve_t>, bp::args("filename"),
+      .def("loadFromText", &piecewise_SE3_t::loadFromText<piecewise_SE3_t>, bp::args("filename"),
            "Loads *this from a text file.")
-      .def("saveAsXML", &piecewise_SE3_curve_t::saveAsXML<piecewise_SE3_curve_t>,
+      .def("saveAsXML", &piecewise_SE3_t::saveAsXML<piecewise_SE3_t>,
            bp::args("filename", "tag_name"), "Saves *this inside a XML file.")
-      .def("loadFromXML", &piecewise_SE3_curve_t::loadFromXML<piecewise_SE3_curve_t>,
+      .def("loadFromXML", &piecewise_SE3_t::loadFromXML<piecewise_SE3_t>,
            bp::args("filename", "tag_name"), "Loads *this from a XML file.")
-      .def("saveAsBinary", &piecewise_SE3_curve_t::saveAsBinary<piecewise_SE3_curve_t>, bp::args("filename"),
+      .def("saveAsBinary", &piecewise_SE3_t::saveAsBinary<piecewise_SE3_t>, bp::args("filename"),
            "Saves *this inside a binary file.")
-      .def("loadFromBinary", &piecewise_SE3_curve_t::loadFromBinary<piecewise_SE3_curve_t>, bp::args("filename"),
+      .def("loadFromBinary", &piecewise_SE3_t::loadFromBinary<piecewise_SE3_t>, bp::args("filename"),
            "Loads *this from a binary file.")
         #ifdef CURVES_WITH_PINOCCHIO_SUPPORT
           .def("evaluateAsSE3", &piecewiseSE3ReturnPinocchio, "Evaluate the curve at the given time. Return as a pinocchio.SE3 object",
@@ -948,12 +861,9 @@ class_<piecewise_SE3_curve_t, bases<curve_abc_t> >("piecewise_SE3_curve", init<>
 
   /** END SE3 Curve**/
   /** BEGIN curves conversion**/
-  def("polynomial_from_bezier", polynomial_from_curve<polynomial_t, bezier_t>);
-  def("polynomial_from_hermite", polynomial_from_curve<polynomial_t, cubic_hermite_spline_t>);
-  def("bezier_from_hermite", bezier_from_curve<bezier_t, cubic_hermite_spline_t>);
-  def("bezier_from_polynomial", bezier_from_curve<bezier_t, polynomial_t>);
-  def("hermite_from_bezier", hermite_from_curve<cubic_hermite_spline_t, bezier_t>);
-  def("hermite_from_polynomial", hermite_from_curve<cubic_hermite_spline_t, polynomial_t>);
+  def("convert_to_polynomial", polynomial_from_curve<polynomial_t>);
+  def("convert_to_bezier", bezier_from_curve<bezier_t>);
+  def("convert_to_hermite", hermite_from_curve<cubic_hermite_spline_t>);
   /** END curves conversion**/
 
   optimization::python::exposeOptimization();

--- a/python/curves_python.cpp
+++ b/python/curves_python.cpp
@@ -452,7 +452,7 @@ BOOST_PYTHON_MODULE(curves) {
       .def("__ne__", &curve_SE3_t::operator!=)
       .def("derivate", pure_virtual(&curve_SE3_t::derivate),
            "Evaluate the derivative of order N of curve at time t. Return as a vector 6.", args("self", "t", "N"))
-      .def("compute_derivate", pure_virtual(&curve_rotation_t::compute_derivate),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
+      .def("compute_derivate", pure_virtual(&curve_SE3_t::compute_derivate),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
       .def("min", pure_virtual(&curve_SE3_t::min), "Get the LOWER bound on interval definition of the curve.")
       .def("max", pure_virtual(&curve_SE3_t::max), "Get the HIGHER bound on interval definition of the curve.")
       .def("dim", pure_virtual(&curve_SE3_t::dim), "Get the dimension of the curve.")

--- a/python/curves_python.cpp
+++ b/python/curves_python.cpp
@@ -16,6 +16,7 @@ using namespace boost::python;
 struct CurveWrapper : curve_abc_t, wrapper<curve_abc_t> {
   point_t operator()(const real) { return this->get_override("operator()")(); }
   point_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
+  curve_t* compute_derivate(const real) { return this->get_override("compute_derivate")(); }
   std::size_t dim() { return this->get_override("dim")(); }
   real min() { return this->get_override("min")(); }
   real max() { return this->get_override("max")(); }
@@ -23,6 +24,7 @@ struct CurveWrapper : curve_abc_t, wrapper<curve_abc_t> {
 struct Curve3Wrapper : curve_3_t, wrapper<curve_3_t> {
   point_t operator()(const real) { return this->get_override("operator()")(); }
   point_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
+  curve_t* compute_derivate(const real) { return this->get_override("compute_derivate")(); }
   std::size_t dim() { return this->get_override("dim")(); }
   real min() { return this->get_override("min")(); }
   real max() { return this->get_override("max")(); }
@@ -30,6 +32,7 @@ struct Curve3Wrapper : curve_3_t, wrapper<curve_3_t> {
 struct CurveRotationWrapper : curve_rotation_t, wrapper<curve_rotation_t> {
   point_t operator()(const real) { return this->get_override("operator()")(); }
   point_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
+  curve_t* compute_derivate(const real) { return this->get_override("compute_derivate")(); }
   std::size_t dim() { return this->get_override("dim")(); }
   real min() { return this->get_override("min")(); }
   real max() { return this->get_override("max")(); }
@@ -37,6 +40,7 @@ struct CurveRotationWrapper : curve_rotation_t, wrapper<curve_rotation_t> {
 struct CurveSE3Wrapper : curve_SE3_t, wrapper<curve_SE3_t> {
   point_t operator()(const real) { return this->get_override("operator()")(); }
   point_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
+  curve_t* compute_derivate(const real) { return this->get_override("compute_derivate")(); }
   std::size_t dim() { return this->get_override("dim")(); }
   real min() { return this->get_override("min")(); }
   real max() { return this->get_override("max")(); }
@@ -398,6 +402,7 @@ BOOST_PYTHON_MODULE(curves) {
            args("self", "t"))
       .def("derivate", pure_virtual(&curve_abc_t::derivate), "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
+      .def("compute_derivate", pure_virtual(&curve_abc_t::compute_derivate),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
       .def("min", pure_virtual(&curve_abc_t::min), "Get the LOWER bound on interval definition of the curve.")
       .def("max", pure_virtual(&curve_abc_t::max), "Get the HIGHER bound on interval definition of the curve.")
       .def("dim", pure_virtual(&curve_abc_t::dim), "Get the dimension of the curve.")
@@ -419,6 +424,7 @@ BOOST_PYTHON_MODULE(curves) {
            args("self", "t"))
       .def("derivate", pure_virtual(&curve_3_t::derivate), "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
+      .def("compute_derivate", pure_virtual(&curve_3_t::compute_derivate),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
       .def("min", pure_virtual(&curve_3_t::min), "Get the LOWER bound on interval definition of the curve.")
       .def("max", pure_virtual(&curve_3_t::max), "Get the HIGHER bound on interval definition of the curve.")
       .def("dim", pure_virtual(&curve_3_t::dim), "Get the dimension of the curve.");
@@ -428,6 +434,7 @@ BOOST_PYTHON_MODULE(curves) {
            args("self", "t"))
       .def("derivate", pure_virtual(&curve_rotation_t::derivate),
            "Evaluate the derivative of order N of curve at time t.", args("self", "t", "N"))
+      .def("compute_derivate", pure_virtual(&curve_rotation_t::compute_derivate),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
       .def("min", pure_virtual(&curve_rotation_t::min), "Get the LOWER bound on interval definition of the curve.")
       .def("max", pure_virtual(&curve_rotation_t::max), "Get the HIGHER bound on interval definition of the curve.")
       .def("dim", pure_virtual(&curve_rotation_t::dim), "Get the dimension of the curve.");
@@ -437,6 +444,7 @@ BOOST_PYTHON_MODULE(curves) {
            args("self", "t"))
       .def("derivate", pure_virtual(&curve_SE3_t::derivate),
            "Evaluate the derivative of order N of curve at time t. Return as a vector 6.", args("self", "t", "N"))
+      .def("compute_derivate", pure_virtual(&curve_rotation_t::compute_derivate),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
       .def("min", pure_virtual(&curve_SE3_t::min), "Get the LOWER bound on interval definition of the curve.")
       .def("max", pure_virtual(&curve_SE3_t::max), "Get the HIGHER bound on interval definition of the curve.")
       .def("dim", pure_virtual(&curve_SE3_t::dim), "Get the dimension of the curve.")
@@ -460,7 +468,6 @@ BOOST_PYTHON_MODULE(curves) {
       .def("__init__", make_constructor(&wrapBezier3ConstructorBounds))
       .def("__init__", make_constructor(&wrapBezier3ConstructorConstraints))
       .def("__init__", make_constructor(&wrapBezier3ConstructorBoundsConstraints))
-      .def("compute_derivate", &bezier3_t::compute_derivate, return_value_policy<manage_new_object>())
       .def("compute_primitive", &bezier3_t::compute_primitive)
       .def("waypointAtIndex", &bezier3_t::waypointAtIndex)
       .def_readonly("degree", &bezier3_t::degree_)
@@ -484,7 +491,6 @@ BOOST_PYTHON_MODULE(curves) {
       .def("__init__", make_constructor(&wrapBezierConstructorBounds))
       .def("__init__", make_constructor(&wrapBezierConstructorConstraints))
       .def("__init__", make_constructor(&wrapBezierConstructorBoundsConstraints))
-      .def("compute_derivate", &bezier_t::compute_derivate, return_value_policy<manage_new_object>())
       .def("compute_primitive", &bezier_t::compute_primitive)
       .def("waypointAtIndex", &bezier_t::waypointAtIndex)
       .def_readonly("degree", &bezier_t::degree_)
@@ -581,7 +587,6 @@ BOOST_PYTHON_MODULE(curves) {
            " ddc(min) == dd_init and ddc(max) == dd_end")
       .def("coeffAtDegree", &polynomial_t::coeffAtDegree)
       .def("coeff", &polynomial_t::coeff)
-      .def("compute_derivate", &polynomial_t::compute_derivate, "Compute derivative of order N of curve at time t.", return_value_policy<manage_new_object>())
       .def("saveAsText", &polynomial_t::saveAsText<polynomial_t>, bp::args("filename"),
            "Saves *this inside a text file.")
       .def("loadFromText", &polynomial_t::loadFromText<polynomial_t>, bp::args("filename"),
@@ -628,8 +633,6 @@ BOOST_PYTHON_MODULE(curves) {
            "and time and connecting exactly self(self.max()) and end. It guarantee C2 continuity and guarantee that "
            "self.derivate(time,1) == d_end and self.derivate(time,2) == dd_end",
            args("self", "end", "d_end", "d_end", "time"))
-      .def("compute_derivate", &piecewise_t::compute_derivate, return_value_policy<manage_new_object>(),
-           "Return a piecewise curve which is the derivate of this.", args("self", "order"))
       .def("append", &piecewise_t::add_curve_ptr,
            "Add a new curve to piecewise curve, which should be defined in T_{min},T_{max}] "
            "where T_{min} is equal toT_{max} of the actual piecewise curve.")
@@ -666,8 +669,6 @@ BOOST_PYTHON_MODULE(curves) {
       "Create a piecewise-se3 curve containing the given se3 curve.")
       .def("__init__", make_constructor(&wrapPiecewiseSE3EmptyConstructor),
       "Create an empty piecewise-se3 curve.")
-      .def("compute_derivate", &piecewise_SE3_t::compute_derivate, return_value_policy<manage_new_object>(),
-           "Return a piecewise_polynomial curve which is the derivate of this.", args("self", "order"))
       .def("append", &piecewise_SE3_t::add_curve_ptr,
            "Add a new curve to piecewise curve, which should be defined in T_{min},T_{max}] "
            "where T_{min} is equal toT_{max} of the actual piecewise curve.",

--- a/python/curves_python.cpp
+++ b/python/curves_python.cpp
@@ -34,6 +34,13 @@ struct CurveRotationWrapper : curve_rotation_t, wrapper<curve_rotation_t> {
   real min() { return this->get_override("min")(); }
   real max() { return this->get_override("max")(); }
 };
+struct CurveSE3Wrapper : curve_SE3_t, wrapper<curve_SE3_t> {
+  point_t operator()(const real) { return this->get_override("operator()")(); }
+  point_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
+  std::size_t dim() { return this->get_override("dim")(); }
+  real min() { return this->get_override("min")(); }
+  real max() { return this->get_override("max")(); }
+};
 /* end base wrap of curve_abc */
 
 /* Template constructor bezier */
@@ -442,6 +449,16 @@ BOOST_PYTHON_MODULE(curves) {
       .def("max", pure_virtual(&curve_rotation_t::max), "Get the HIGHER bound on interval definition of the curve.")
       .def("dim", pure_virtual(&curve_rotation_t::dim), "Get the dimension of the curve.");
 
+  class_<CurveSE3Wrapper, boost::noncopyable, bases<curve_abc_t> >("curve_SE3", no_init)
+      .def("__call__", pure_virtual(&curve_SE3_t::operator()), "Evaluate the curve at the given time.",
+           args("self", "t"))
+      .def("derivate", pure_virtual(&curve_SE3_t::derivate),
+           "Evaluate the derivative of order N of curve at time t.", args("self", "t", "N"))
+      .def("min", pure_virtual(&curve_SE3_t::min), "Get the LOWER bound on interval definition of the curve.")
+      .def("max", pure_virtual(&curve_SE3_t::max), "Get the HIGHER bound on interval definition of the curve.")
+      .def("dim", pure_virtual(&curve_SE3_t::dim), "Get the dimension of the curve.");
+
+
   /** BEGIN bezier3 curve**/
   class_<bezier3_t, bases<curve_3_t> >("bezier3", init<>())
       .def("__init__", make_constructor(&wrapBezier3Constructor))
@@ -787,7 +804,7 @@ BOOST_PYTHON_MODULE(curves) {
 
   /** END  SO3 Linear**/
   /** BEGIN SE3 Curve**/
-  class_<SE3Curve_t, bases<curve_abc_t> >("SE3Curve", init<>())
+  class_<SE3Curve_t, bases<curve_SE3_t> >("SE3Curve", init<>())
       .def("__init__",
            make_constructor(&wrapSE3CurveFromTransform, default_call_policies(),
                             args("init_transform", "end_transform", "min", "max")),

--- a/python/curves_python.cpp
+++ b/python/curves_python.cpp
@@ -448,7 +448,7 @@ BOOST_PYTHON_MODULE(curves) {
       .def("__init__", make_constructor(&wrapBezier3ConstructorBounds))
       .def("__init__", make_constructor(&wrapBezier3ConstructorConstraints))
       .def("__init__", make_constructor(&wrapBezier3ConstructorBoundsConstraints))
-      .def("compute_derivate", &bezier3_t::compute_derivate)
+      .def("compute_derivate", &bezier3_t::compute_derivate, return_value_policy<manage_new_object>())
       .def("compute_primitive", &bezier3_t::compute_primitive)
       .def("waypointAtIndex", &bezier3_t::waypointAtIndex)
       .def_readonly("degree", &bezier3_t::degree_)
@@ -472,7 +472,7 @@ BOOST_PYTHON_MODULE(curves) {
       .def("__init__", make_constructor(&wrapBezierConstructorBounds))
       .def("__init__", make_constructor(&wrapBezierConstructorConstraints))
       .def("__init__", make_constructor(&wrapBezierConstructorBoundsConstraints))
-      .def("compute_derivate", &bezier_t::compute_derivate)
+      .def("compute_derivate", &bezier_t::compute_derivate, return_value_policy<manage_new_object>())
       .def("compute_primitive", &bezier_t::compute_primitive)
       .def("waypointAtIndex", &bezier_t::waypointAtIndex)
       .def_readonly("degree", &bezier_t::degree_)
@@ -522,7 +522,7 @@ BOOST_PYTHON_MODULE(curves) {
       .def("__call__", &bezier_linear_variable_t::operator())
       .def("evaluate", &bezier_linear_variable_t_evaluate, bp::return_value_policy<bp::manage_new_object>())
       .def("derivate", &bezier_linear_variable_t::derivate)
-      .def("compute_derivate", &bezier_linear_variable_t::compute_derivate)
+      .def("compute_derivate", &bezier_linear_variable_t::compute_derivate, return_value_policy<manage_new_object>())
       .def("compute_primitive", &bezier_linear_variable_t::compute_primitive)
       .def("split", split_py)
       .def("waypoints", &wayPointsToLists, return_value_policy<manage_new_object>())
@@ -569,7 +569,7 @@ BOOST_PYTHON_MODULE(curves) {
            " ddc(min) == dd_init and ddc(max) == dd_end")
       .def("coeffAtDegree", &polynomial_t::coeffAtDegree)
       .def("coeff", &polynomial_t::coeff)
-      .def("compute_derivate", &polynomial_t::compute_derivate, "Compute derivative of order N of curve at time t.")
+      .def("compute_derivate", &polynomial_t::compute_derivate, "Compute derivative of order N of curve at time t.", return_value_policy<manage_new_object>())
       .def("saveAsText", &polynomial_t::saveAsText<polynomial_t>, bp::args("filename"),
            "Saves *this inside a text file.")
       .def("loadFromText", &polynomial_t::loadFromText<polynomial_t>, bp::args("filename"),
@@ -616,7 +616,7 @@ BOOST_PYTHON_MODULE(curves) {
            "and time and connecting exactly self(self.max()) and end. It guarantee C2 continuity and guarantee that "
            "self.derivate(time,1) == d_end and self.derivate(time,2) == dd_end",
            args("self", "end", "d_end", "d_end", "time"))
-      .def("compute_derivate", &piecewise_t::compute_derivate,
+      .def("compute_derivate", &piecewise_t::compute_derivate, return_value_policy<manage_new_object>(),
            "Return a piecewise curve which is the derivate of this.", args("self", "order"))
       .def("append", &piecewise_t::add_curve_ptr,
            "Add a new curve to piecewise curve, which should be defined in T_{min},T_{max}] "
@@ -649,12 +649,12 @@ BOOST_PYTHON_MODULE(curves) {
       .def("loadFromBinary", &piecewise_t::loadFromBinary<piecewise_t>,
            bp::args("filename"), "Loads *this from a binary file.");
 
-  class_<piecewise_SE3_t, bases<curve_abc_t> >("piecewise_SE3", init<>())
+  class_<piecewise_SE3_t, bases<curve_SE3_t> >("piecewise_SE3", init<>())
       .def("__init__", make_constructor(&wrapPiecewiseSE3Constructor, default_call_policies(), arg("curve")),
       "Create a piecewise-se3 curve containing the given se3 curve.")
       .def("__init__", make_constructor(&wrapPiecewiseSE3EmptyConstructor),
       "Create an empty piecewise-se3 curve.")
-      .def("compute_derivate", &piecewise_SE3_t::compute_derivate,
+      .def("compute_derivate", &piecewise_SE3_t::compute_derivate, return_value_policy<manage_new_object>(),
            "Return a piecewise_polynomial curve which is the derivate of this.", args("self", "order"))
       .def("append", &piecewise_SE3_t::add_curve_ptr,
            "Add a new curve to piecewise curve, which should be defined in T_{min},T_{max}] "

--- a/python/curves_python.cpp
+++ b/python/curves_python.cpp
@@ -641,7 +641,7 @@ BOOST_PYTHON_MODULE(curves) {
       .def("is_continuous", &piecewise_t::is_continuous,
            "Check if the curve is continuous at the given order.",args("self,order"))
       .def("convert_piecewise_curve_to_polynomial",
-           &piecewise_t::convert_piecewise_curve_to_bezier<polynomial_t>,
+           &piecewise_t::convert_piecewise_curve_to_polynomial<polynomial_t>,
            "Convert a piecewise curve to to a piecewise polynomial curve")
       .def("convert_piecewise_curve_to_bezier",
            &piecewise_t::convert_piecewise_curve_to_bezier<bezier_t>,

--- a/python/python_definitions.h
+++ b/python/python_definitions.h
@@ -1,3 +1,4 @@
+#include "curves/fwd.h"
 #include "curves/bezier_curve.h"
 #include "curves/linear_variable.h"
 #include "curves/quadratic_variable.h"
@@ -8,25 +9,44 @@
 #define _DEFINITION_PYTHON_BINDINGS
 
 namespace curves {
+/*** TEMPLATE SPECIALIZATION FOR PYTHON ****/
 typedef double real;
-typedef Eigen::Vector3d point_t;
+typedef std::vector<real> t_time_t;
+typedef Eigen::VectorXd time_waypoints_t;
+
+typedef Eigen::Matrix<double, Eigen::Dynamic, 1, 0, Eigen::Dynamic, 1> ret_pointX_t;
+typedef std::pair<pointX_t, pointX_t> pair_pointX_tangent_t;
+typedef Eigen::MatrixXd pointX_list_t;
+typedef std::vector<pair_pointX_tangent_t, Eigen::aligned_allocator<pair_pointX_tangent_t> > t_pair_pointX_tangent_t;
+typedef curves::curve_constraints<pointX_t> curve_constraints_t;
+typedef curves::curve_constraints<point3_t> curve_constraints3_t;
+typedef std::pair<real, pointX_t> waypoint_t;
+typedef std::vector<waypoint_t> t_waypoint_t;
+typedef Eigen::Matrix<real, Eigen::Dynamic, Eigen::Dynamic> point_listX_t;
+typedef Eigen::Matrix<real, 3, Eigen::Dynamic> point_list3_t;
+typedef Eigen::Matrix<real, 6, Eigen::Dynamic> point_list6_t;
+
+typedef polynomial_t::coeff_t coeff_t;
+typedef curves::Bern<double> bernstein_t;
+/*
+typedef double real;
+typedef Eigen::Vector3d point3_t;
 typedef Eigen::Vector3d tangent_t;
 typedef Eigen::VectorXd vectorX_t;
-typedef std::pair<point_t, tangent_t> pair_point_tangent_t;
+typedef std::pair<point3_t, tangent_t> pair_point_tangent_t;
 typedef Eigen::Matrix<double, 6, 1, 0, 6, 1> point6_t;
 typedef Eigen::Matrix<double, 3, 1, 0, 3, 1> ret_point_t;
 typedef Eigen::Matrix<double, 6, 1, 0, 6, 1> ret_point6_t;
 typedef Eigen::VectorXd time_waypoints_t;
 typedef Eigen::Matrix<real, 3, Eigen::Dynamic> point_list_t;
 typedef Eigen::Matrix<real, 6, Eigen::Dynamic> point_list6_t;
-typedef std::vector<real> t_time_t;
-typedef std::vector<point_t, Eigen::aligned_allocator<point_t> > t_point_t;
+typedef std::vector<point3_t, Eigen::aligned_allocator<point3_t> > t_point3_t;
 typedef std::vector<point6_t, Eigen::aligned_allocator<point6_t> > t_point6_t;
-typedef std::pair<real, point_t> Waypoint;
+typedef std::pair<real, point3_t> Waypoint;
 typedef std::vector<Waypoint> T_Waypoint;
 typedef std::pair<real, point6_t> Waypoint6;
 typedef std::vector<Waypoint6> T_Waypoint6;
-
+*/
 template <typename PointList, typename T_Point>
 T_Point vectorFromEigenArray(const PointList& array) {
   T_Point res;

--- a/python/python_variables.cpp
+++ b/python/python_variables.cpp
@@ -4,7 +4,7 @@
 #include <Eigen/Core>
 
 namespace curves {
-std::vector<linear_variable_t> matrix3DFromEigenArray(const point_list_t& matrices, const point_list_t& vectors) {
+std::vector<linear_variable_t> matrix3DFromEigenArray(const point_list3_t& matrices, const point_list3_t& vectors) {
   assert(vectors.cols() * 3 == matrices.cols());
   std::vector<linear_variable_t> res;
   for (int i = 0; i < vectors.cols(); ++i) {
@@ -19,7 +19,7 @@ linear_variable_t fillWithZeros(const linear_variable_t& var, const std::size_t 
   return linear_variable_t(B, var.c());
 }
 
-std::vector<linear_variable_t> computeLinearControlPoints(const point_list_t& matrices, const point_list_t& vectors) {
+std::vector<linear_variable_t> computeLinearControlPoints(const point_list3_t& matrices, const point_list3_t& vectors) {
   std::vector<linear_variable_t> res;
   std::vector<linear_variable_t> variables = matrix3DFromEigenArray(matrices, vectors);
   // now need to fill all this with zeros...
@@ -29,12 +29,12 @@ std::vector<linear_variable_t> computeLinearControlPoints(const point_list_t& ma
 }
 
 /*linear variable control points*/
-bezier_linear_variable_t* wrapBezierLinearConstructor(const point_list_t& matrices, const point_list_t& vectors) {
+bezier_linear_variable_t* wrapBezierLinearConstructor(const point_list3_t& matrices, const point_list3_t& vectors) {
   std::vector<linear_variable_t> asVector = computeLinearControlPoints(matrices, vectors);
   return new bezier_linear_variable_t(asVector.begin(), asVector.end());
 }
 
-bezier_linear_variable_t* wrapBezierLinearConstructorBounds(const point_list_t& matrices, const point_list_t& vectors,
+bezier_linear_variable_t* wrapBezierLinearConstructorBounds(const point_list3_t& matrices, const point_list3_t& vectors,
                                                             const real T_min, const real T_max) {
   std::vector<linear_variable_t> asVector = computeLinearControlPoints(matrices, vectors);
   return new bezier_linear_variable_t(asVector.begin(), asVector.end(), T_min, T_max);

--- a/python/python_variables.h
+++ b/python/python_variables.h
@@ -1,3 +1,4 @@
+#include "curves/fwd.h"
 #include "curves/linear_variable.h"
 #include "curves/bezier_curve.h"
 #include "curves/polynomial.h"
@@ -27,8 +28,8 @@ typedef quadratic_variable<real> quadratic_variable_t;
 typedef bezier_curve<real, real, true, linear_variable_t> bezier_linear_variable_t;
 
 /*linear variable control points*/
-bezier_linear_variable_t* wrapBezierLinearConstructor(const point_list_t& matrices, const point_list_t& vectors);
-bezier_linear_variable_t* wrapBezierLinearConstructorBounds(const point_list_t& matrices, const point_list_t& vectors,
+bezier_linear_variable_t* wrapBezierLinearConstructor(const point_list3_t& matrices, const point_list3_t& vectors);
+bezier_linear_variable_t* wrapBezierLinearConstructorBounds(const point_list3_t& matrices, const point_list3_t& vectors,
                                                             const real T_min, const real T_max);
 
 typedef Eigen::Matrix<real, Eigen::Dynamic, Eigen::Dynamic> matrix_x_t;
@@ -57,74 +58,29 @@ struct LinearBezierVector {
   }
 };
 
-/*** TEMPLATE SPECIALIZATION FOR PYTHON ****/
-typedef double real;
-typedef Eigen::VectorXd time_waypoints_t;
-
-typedef Eigen::VectorXd pointX_t;
-typedef Eigen::Matrix<double, 3, 1> point3_t;
-typedef Eigen::Matrix<double, Eigen::Dynamic, 1, 0, Eigen::Dynamic, 1> ret_pointX_t;
-typedef std::pair<pointX_t, pointX_t> pair_pointX_tangent_t;
-typedef Eigen::MatrixXd pointX_list_t;
-typedef std::vector<pointX_t, Eigen::aligned_allocator<pointX_t> > t_pointX_t;
-typedef std::vector<pointX_t, Eigen::aligned_allocator<point3_t> > t_point3_t;
-typedef std::vector<pair_pointX_tangent_t, Eigen::aligned_allocator<pair_pointX_tangent_t> > t_pair_pointX_tangent_t;
-typedef curves::curve_constraints<pointX_t> curve_constraints_t;
-typedef curves::curve_constraints<point3_t> curve_constraints3_t;
-typedef std::pair<real, pointX_t> waypoint_t;
-typedef std::vector<waypoint_t> t_waypoint_t;
-typedef Eigen::Matrix<real, 3, 3> matrix3_t;
-typedef Eigen::Matrix<real, 4, 4> matrix4_t;
-typedef Eigen::Transform<double, 3, Eigen::Affine> transform_t;
-typedef Eigen::Quaternion<real> quaternion_t;
-
-// Curves
-typedef curve_abc<real, real, true, pointX_t> curve_abc_t;  // generic class of curve
-typedef curve_abc<real, real, true, point3_t> curve_3_t;    // generic class of curve of size 3
-typedef curve_abc<real, real, true, matrix3_t, point3_t>
-    curve_rotation_t;  // templated class used for the rotation (return dimension are fixed)
-typedef boost::shared_ptr<curve_abc_t> curve_ptr_t;
-typedef boost::shared_ptr<curve_rotation_t> curve_rotation_ptr_t;
-typedef curves::cubic_hermite_spline<real, real, true, pointX_t> cubic_hermite_spline_t;
-typedef curves::bezier_curve<real, real, true, pointX_t> bezier_t;
-typedef curves::bezier_curve<real, real, true, Eigen::Vector3d> bezier3_t;
-typedef curves::polynomial<real, real, true, pointX_t, t_pointX_t> polynomial_t;
-typedef polynomial_t::coeff_t coeff_t;
-typedef curves::piecewise_curve<real, real, true, pointX_t, t_pointX_t, polynomial_t> piecewise_polynomial_curve_t;
-typedef curves::piecewise_curve<real, real, true, pointX_t, t_pointX_t, bezier_t> piecewise_bezier_curve_t;
-typedef curves::piecewise_curve<real, real, true, pointX_t, t_pointX_t, cubic_hermite_spline_t>
-    piecewise_cubic_hermite_curve_t;
-typedef curves::piecewise_curve<real, real, true, linear_variable_t,
-                                std::vector<linear_variable_t, Eigen::aligned_allocator<linear_variable_t> >,
-                                bezier_linear_variable_t>
-    piecewise_bezier_linear_curve_t;
-typedef curves::exact_cubic<real, real, true, pointX_t, t_pointX_t> exact_cubic_t;
-typedef SO3Linear<double, double, true> SO3Linear_t;
-typedef SE3Curve<double, double, true> SE3Curve_t;
-typedef curves::piecewise_curve<real, real, true, SE3Curve_t::point_t, t_pointX_t, SE3Curve_t,SE3Curve_t::point_derivate_t> piecewise_SE3_curve_t;
-typedef curves::Bern<double> bernstein_t;
 
 /*** TEMPLATE SPECIALIZATION FOR PYTHON ****/
 }  // namespace curves
-
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::bernstein_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::cubic_hermite_spline_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::bezier_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::bezier3_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::polynomial_t)
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::curve_constraints_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::piecewise_polynomial_curve_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::piecewise_bezier_curve_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::piecewise_cubic_hermite_curve_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::piecewise_bezier_linear_curve_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::exact_cubic_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::SO3Linear_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::SE3Curve_t)
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::piecewise_SE3_curve_t)
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::matrix_x_t)
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::pointX_t)
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::linear_variable_t)
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::bezier_linear_variable_t)
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::matrix_pair)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::polynomial_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::exact_cubic_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::bezier_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::cubic_hermite_spline_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::piecewise_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::polynomial3_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::exact_cubic3_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::bezier3_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::cubic_hermite_spline3_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::piecewise3_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::SO3Linear_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::SE3Curve_t)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(curves::piecewise_SE3_t)
+
 
 #endif  //_VARIABLES_PYTHON_BINDINGS

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -1187,6 +1187,58 @@ class TestCurves(unittest.TestCase):
         se3_bin.loadFromBinary("serialization_curve")
         self.compareCurves(se3_curves,se3_bin)
 
+    def test_operatorEqual(self):
+        # test with bezier
+        waypoints = array([[1., 2., 3.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.]]).transpose()
+        a0 = bezier(waypoints)
+        a1 = bezier(waypoints, 0., 3.)
+        a2 = bezier(waypoints, 0., 3.)
+        self.assertTrue(a0 != a1)
+        self.assertTrue(a1 == a2)
+
+        # test with polynomials of degree 5
+        p0 = array([1., 3., -2.])
+        p1 = array([0.6, 2., 2.5])
+        dp0 = array([-6., 2., -1.])
+        dp1 = array([10., 10., 10.])
+        ddp0 = array([1., -7., 4.5])
+        ddp1 = array([6., -1., -4])
+        min = 1.
+        max = 2.5
+        pol_1 = polynomial(p0.reshape(-1,1), dp0.reshape(-1,1), ddp0.reshape(-1,1), p1.reshape(-1,1), dp1.reshape(-1,1), ddp1.reshape(-1,1), min, max)
+        pol_2 = polynomial(p0.reshape(-1,1), dp0.reshape(-1,1), ddp0.reshape(-1,1), p1.reshape(-1,1), dp1.reshape(-1,1), ddp1.reshape(-1,1), min, max)
+        pol_3 = polynomial(p1.reshape(-1,1), dp0.reshape(-1,1), ddp0.reshape(-1,1), p0.reshape(-1,1), dp1.reshape(-1,1), ddp1.reshape(-1,1), min, max)
+        self.assertTrue(pol_1 == pol_2)
+        self.assertTrue(pol_1 != pol_3)
+
+        # test with polynomial/bezier
+        pol_4 = polynomial(p0.reshape(-1,1), dp0.reshape(-1,1), p1.reshape(-1,1), dp1.reshape(-1,1), min, max)
+        b_4 = convert_to_bezier(pol_4)
+        self.assertTrue(pol_4 == b_4)
+        self.assertTrue(pol_4 != a1)
+
+        #test with SE3 :
+        init_quat = Quaternion.Identity()
+        end_quat = Quaternion(sqrt(2.) / 2., sqrt(2.) / 2., 0, 0)
+        init_rot = init_quat.matrix()
+        end_rot = end_quat.matrix()
+        waypoints = array([[1., 2., 3.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.]]).transpose()
+        min = 0.2
+        max = 1.5
+        translation = bezier(waypoints, min, max)
+        se3_1 = SE3Curve(translation, init_rot, end_rot)
+        se3_2 = SE3Curve(translation, init_rot, end_rot)
+        waypoints2 = array([[1., 2., 3.5], [4., 5., 6.], [-4, 5., 6.], [4., 8., 6.], [4., 5., 6.]]).transpose()
+        translation3 = bezier(waypoints2, min, max)
+        se3_3 = SE3Curve(translation3, init_rot, end_rot)
+        end_quat2 = Quaternion(sqrt(2.) / 2.,0.,  sqrt(2.) / 2., 0)
+        end_rot2 = end_quat2.matrix()
+        se3_4 = SE3Curve(translation, init_rot, end_rot2)
+        self.assertTrue(se3_1 == se3_2)
+        self.assertTrue(se3_1 != se3_3)
+        self.assertTrue(se3_1 != se3_4)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -752,17 +752,17 @@ class TestCurves(unittest.TestCase):
         waypoints = array([[1., 2., 3.], [4., 5., 6.]]).transpose()
         a = bezier(waypoints, 0., 1.)
         b = bezier(waypoints, 1., 2.)
-        pc = piecewise_bezier_curve(a)
+        pc = piecewise(a)
         pc.append(b)
         # Convert to piecewise polynomial
         pc_pol = pc.convert_piecewise_curve_to_polynomial()
-        self.assertTrue(norm(pc_pol(0.3) - pc(0.3)) < __EPS)
+        self.compareCurves(pc_pol, pc)
         # Convert to piecewise cubic hermite
         pc_chs = pc.convert_piecewise_curve_to_cubic_hermite()
-        self.assertTrue(norm(pc_chs(0.3) - pc(0.3)) < __EPS)
+        self.compareCurves(pc_chs, pc)
         # Convert to piecewise bezier
         pc_bc = pc_chs.convert_piecewise_curve_to_bezier()
-        self.assertTrue(norm(pc_bc(0.3) - pc(0.3)) < __EPS)
+        self.compareCurves(pc_bc, pc)
         return
 
     def test_so3_linear(self):

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -26,13 +26,15 @@ class TestCurves(unittest.TestCase):
     def compareCurves(self,c1,c2):
         t_min = c1.min()
         t_max = c1.max()
-        self.assertEqual(t_min,c2.min())
-        self.assertEqual(t_max,c2.max())
-        self.assertTrue(norm(c1.derivate(t_min, 1) - c2.derivate(t_min, 1)) < 1e-10)
-        self.assertTrue(norm(c1.derivate(t_max, 1) - c2.derivate(t_max, 1)) < 1e-10)
+        self.assertEqual(t_min,c2.min(),"c1 min : "+str(t_min)+" ; c2 min : "+str(c2.min()))
+        self.assertEqual(t_max,c2.max(),"c1 max : "+str(t_max)+" ; c2 max : "+str(c2.max()))
+        self.assertTrue(norm(c1.derivate(t_min, 1) - c2.derivate(t_min, 1)) < 1e-10,
+        "dc1(tmin) = "+str(c1.derivate(t_min, 1))+" ; dc2(tmin) = "+str(c2.derivate(t_min, 1)))
+        self.assertTrue(norm(c1.derivate(t_max, 1) - c2.derivate(t_max, 1)) < 1e-10,
+        "dc1(tmax) = "+str(c1.derivate(t_max, 1))+" ; dc2(tmax) = "+str(c2.derivate(t_max, 1)))
         t = t_min
         while t < t_max:
-          self.assertTrue(norm(c1(t) - c2(t)) < 1e-10)
+          self.assertTrue(norm(c1(t) - c2(t)) < 1e-10," at t = "+str(t)+" c1 = "+str(c1(t))+" ; c2 = "+str(c2(t)))
           t = t+0.01
 
 

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -2320,6 +2320,276 @@ void BezierLinearProblemsetupLoadProblem(bool& /*error*/) {
   // initInequalityMatrix<point_t,3,double>(pDef,pData,prob);
 }
 
+void testOperatorEqual(bool& error){
+  // test with a C2 polynomial :
+  pointX_t zeros = point3_t(0., 0., 0.);
+  pointX_t p0 = point3_t(0., 1., 0.);
+  pointX_t p1 = point3_t(1., 2., -3.);
+  pointX_t dp0 = point3_t(-8., 4., 6.);
+  pointX_t dp1 = point3_t(10., -10., 10.);
+  pointX_t ddp0 = point3_t(-1., 7., 4.);
+  pointX_t ddp1 = point3_t(12., -8., 2.5);
+  double min = 0.5;
+  double max = 2.;
+  polynomial_t polC2_1 = polynomial_t(p0, dp0, ddp0, p1, dp1, ddp1, min, max);
+  polynomial_t polC2_2 = polynomial_t(p0, dp0, ddp0, p1, dp1, ddp1, min, max);
+  polynomial_t polC2_3(polC2_1);
+
+  if(polC2_1 != polC2_2){
+    std::cout<<"polC2_1 and polC2_2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(polC2_1 != polC2_3){
+    std::cout<<"polC2_1 and polC2_3 should be equals"<<std::endl;
+    error = true;
+  }
+
+  polynomial_t polC2_4 = polynomial_t(p1, dp0, ddp0, p1, dp1, ddp0, min, max);
+  if(polC2_1 == polC2_4){
+    std::cout<<"polC2_1 and polC2_4 should not be equals"<<std::endl;
+    error = true;
+  }
+
+  // test with bezier
+  point3_t a(1, 2, 3);
+  point3_t b(2, 3, 4);
+  point3_t c(3, 4, 5);
+  point3_t d(3, 6, 7);
+  point3_t e(3, 61, 7);
+  point3_t f(3, 56, 7);
+  point3_t g(3, 36, 7);
+  point3_t h(43, 6, 7);
+  point3_t i(3, 6, 77);
+  std::vector<point3_t> control_points;
+  control_points.push_back(a);
+  control_points.push_back(b);
+  control_points.push_back(c);
+  control_points.push_back(d);
+  control_points.push_back(e);
+  control_points.push_back(f);
+  control_points.push_back(g);
+  control_points.push_back(h);
+  control_points.push_back(i);
+  bezier_t::num_t T_min = 1.0;
+  bezier_t::num_t T_max = 3.0;
+  bezier_t bc_0(control_points.begin(), control_points.end(), T_min, T_max);
+  bezier_t bc_1(bc_0);
+  if(bc_1 != bc_0){
+    std::cout<<"bc_0 and bc_1 should be equals"<<std::endl;
+    error = true;
+  }
+  std::vector<point3_t> control_points2;
+  control_points2.push_back(a);
+  control_points2.push_back(b);
+  control_points2.push_back(c);
+  control_points2.push_back(d);
+  bezier_t bc_2(control_points2.begin(), control_points2.end(), T_min, T_max);
+  if(bc_2 == bc_0){
+    std::cout<<"bc_0 and bc_2 should not be equals"<<std::endl;
+    error = true;
+  }
+  polynomial_t pol_2 = polynomial_from_curve<polynomial_t>(bc_2);
+  bezier_t bc_3 = bezier_from_curve<bezier_t>(pol_2);
+  if(bc_2 != bc_3){
+    std::cout<<"bc_2 and bc_3 should be equals"<<std::endl;
+    error = true;
+  }
+
+  // test bezier / polynomial
+  polynomial_t pol_0 = polynomial_from_curve<polynomial_t>(bc_0);
+  CompareCurves<polynomial_t,bezier_t>(pol_0,bc_0,"compare pol_0 and bc_0",error);
+  if(bc_0 != pol_0){
+    std::cout<<"bc_0 and pol_0 should be equals"<<std::endl;
+    error = true;
+  }
+
+  // test with hermite :
+  point3_t ch_p0(1, 2, 3);
+  point3_t ch_m0(2, 3, 4);
+  point3_t ch_p1(3, 4, 5);
+  point3_t ch_m1(3, 6, 7);
+  pair_point_tangent_t pair0(ch_p0, ch_m0);
+  pair_point_tangent_t pair1(ch_p1, ch_m1);
+  t_pair_point_tangent_t ch_control_points;
+  ch_control_points.push_back(pair0);
+  ch_control_points.push_back(pair1);
+  std::vector<double> time_control_points;
+  time_control_points.push_back(T_min);
+  time_control_points.push_back(T_max);
+  cubic_hermite_spline_t chs0(ch_control_points.begin(), ch_control_points.end(), time_control_points);
+  cubic_hermite_spline_t chs1(ch_control_points.begin(), ch_control_points.end(), time_control_points);
+  cubic_hermite_spline_t chs2(chs0);
+  point3_t ch_p2(3.1, 4, 5);
+  point3_t ch_m2(3, 6.5, 6.);
+  pair_point_tangent_t pair2(ch_p2, ch_m2);
+  t_pair_point_tangent_t ch_control_points2;
+  ch_control_points2.push_back(pair0);
+  ch_control_points2.push_back(pair2);
+  cubic_hermite_spline_t chs3(ch_control_points2.begin(), ch_control_points2.end(), time_control_points);
+  if(chs0 != chs1){
+    std::cout<<"chs0 and chs1 should be equals"<<std::endl;
+    error = true;
+  }
+  if(chs0 != chs2){
+    std::cout<<"chs0 and chs2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(chs0 == chs3){
+    std::cout<<"chs0 and chs3 should not be equals"<<std::endl;
+    error = true;
+  }
+
+//  // test bezier / hermite
+  bezier_t bc_ch = bezier_from_curve<bezier_t>(chs0);
+  if(chs0 != bc_ch){
+    std::cout<<"chs0 and bc_ch should be equals"<<std::endl;
+    error = true;
+  }
+  // test polynomial / hermite
+  polynomial_t pol_ch = polynomial_from_curve<polynomial_t>(chs0);
+  if(chs0 != pol_ch){
+    std::cout<<"chs0 and pol_ch should be equals"<<std::endl;
+    error = true;
+  }
+
+  // SO3
+  quaternion_t q0(1, 0, 0, 0);
+  quaternion_t q1(0.7071, 0.7071, 0, 0);
+  q0.normalize();
+  q1.normalize();
+  const double tMin = 0.;
+  const double tMax = 1.5;
+  SO3Linear_t so3Traj1(q0, q1, tMin, tMax);
+  SO3Linear_t so3Traj2(q0, q1, tMin, tMax);
+  SO3Linear_t so3TrajMatrix1(q0.toRotationMatrix(), q1.toRotationMatrix(), tMin, tMax);
+  SO3Linear_t so3TrajMatrix2(so3TrajMatrix1);
+  quaternion_t q2(0.7071, 0., 0.7071, 0);
+  q2.normalize();
+  SO3Linear_t so3Traj3(q0, q2, tMin, tMax);
+  if(so3Traj1 != so3Traj2){
+    std::cout<<"so3Traj1 and so3Traj2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(so3Traj1 != so3TrajMatrix1){
+    std::cout<<"so3Traj1 and so3TrajMatrix1 should be equals"<<std::endl;
+    error = true;
+  }
+  if(so3Traj1 != so3TrajMatrix2){
+    std::cout<<"so3Traj1 and so3TrajMatrix2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(so3Traj1 == so3Traj3){
+    std::cout<<"so3Traj1 and so3Traj3 should not be equals"<<std::endl;
+    error = true;
+  }
+
+  // SE3
+  boost::shared_ptr<bezier_t> translation_bezier(new bezier_t(bc_0));
+  boost::shared_ptr<polynomial_t> translation_polynomial(new polynomial_t(pol_0));
+  SE3Curve_t se3_bezier1 = SE3Curve_t(translation_bezier, q0.toRotationMatrix(), q1.toRotationMatrix());
+  SE3Curve_t se3_pol1 = SE3Curve_t(translation_polynomial, q0.toRotationMatrix(), q1.toRotationMatrix());
+  SE3Curve_t se3_bezier2(se3_bezier1);
+  SE3Curve_t se3_bezier3 = SE3Curve_t(translation_bezier, q0.toRotationMatrix(), q2.toRotationMatrix());
+  boost::shared_ptr<polynomial_t> translation_polynomial2(new polynomial_t(pol_2));
+  SE3Curve_t se3_pol2 = SE3Curve_t(translation_polynomial2, q0.toRotationMatrix(), q1.toRotationMatrix());
+  if(se3_bezier1 != se3_pol1){
+    std::cout<<"se3_bezier1 and se3_pol1 should be equals"<<std::endl;
+    error = true;
+  }
+  if(se3_bezier1 != se3_bezier2){
+    std::cout<<"se3_bezier1 and se3_bezier2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(se3_bezier1 == se3_pol2){
+    std::cout<<"se3_bezier1 and se3_pol2 should not be equals"<<std::endl;
+    error = true;
+  }
+  if(se3_bezier1 == se3_bezier3){
+    std::cout<<"se3_bezier1 and se3_bezier3 should not be equals"<<std::endl;
+    error = true;
+  }
+
+  // Piecewises
+  point3_t a0(1, 2, 3);
+  point3_t b0(2, 3, 4);
+  point3_t c0(3, 4, 5);
+  point3_t d0(4, 5, 6);
+  std::vector<point3_t> params0;
+  std::vector<point3_t> params1;
+  params0.push_back(a0);  // bezier between [0,1]
+  params0.push_back(b0);
+  params0.push_back(c0);
+  params0.push_back(d0);
+  params1.push_back(d0);  // bezier between [1,2]
+  params1.push_back(c0);
+  params1.push_back(b0);
+  params1.push_back(a0);
+  boost::shared_ptr<bezier_t> bc0_ptr(new bezier_t(params0.begin(), params0.end(), 0., 1.));
+  boost::shared_ptr<bezier_t> bc1_ptr(new bezier_t(params1.begin(), params1.end(), 1., 2.));
+  piecewise_t pc_C0(bc0_ptr);
+  pc_C0.add_curve_ptr(bc1_ptr);
+  piecewise_t pc_C1(bc0_ptr);
+  pc_C1.add_curve_ptr(bc1_ptr);
+  piecewise_t pc_C2(pc_C0);
+  piecewise_t pc_C3(bc0_ptr);
+  piecewise_t pc_C4(bc0_ptr);
+  boost::shared_ptr<bezier_t> bc2_ptr(new bezier_t(params0.begin(), params0.end(), 1., 2.));
+  pc_C4.add_curve_ptr(bc2_ptr);
+
+  if(pc_C0 != pc_C1){
+    std::cout<<"pc_C0 and pc_C1 should be equals"<<std::endl;
+    error = true;
+  }
+  if(pc_C0 != pc_C2){
+    std::cout<<"pc_C0 and pc_C2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(pc_C0 == pc_C3){
+    std::cout<<"pc_C0 and pc_C3 should not be equals"<<std::endl;
+    error = true;
+  }
+  if(pc_C0 == pc_C4){
+    std::cout<<"pc_C0 and pc_C4 should not be equals"<<std::endl;
+    error = true;
+  }
+  // piecewise with mixed curves types
+  piecewise_t pc_C5 =  pc_C0.convert_piecewise_curve_to_polynomial<polynomial_t>();
+  if(pc_C0 != pc_C5){
+    std::cout<<"pc_C0 and pc_C5 should be equals"<<std::endl;
+    error = true;
+  }
+
+  // piecewise se3 :
+  piecewise_SE3_t pc_se3_1;
+  pc_se3_1.add_curve(se3_pol1);
+  point3_t p_init_se3(translation_polynomial->operator()(translation_polynomial->max()));
+  point3_t dp_init_se3(translation_polynomial->derivate(translation_polynomial->max(),1));
+  point3_t p_end_se3(1,-2,6);
+  point3_t dp_end_se3(3.5,2.5,-9);
+  boost::shared_ptr<polynomial_t> translation_pol3(new polynomial_t(p_init_se3,dp_init_se3,p_end_se3,dp_end_se3,translation_polynomial->max(),translation_polynomial->max()+2.5));
+  curve_SE3_ptr_t se3_pol_3(new SE3Curve_t(translation_pol3,q1.toRotationMatrix(),q2.toRotationMatrix()));
+  pc_se3_1.add_curve_ptr(se3_pol_3);
+  piecewise_SE3_t pc_se3_2(pc_se3_1);
+  piecewise_SE3_t pc_se3_3(boost::make_shared<SE3Curve_t>(se3_pol1));
+  pc_se3_3.add_curve_ptr(se3_pol_3);
+  piecewise_SE3_t pc_se3_4(boost::make_shared<SE3Curve_t>(se3_pol2));
+  pc_se3_4.add_curve_ptr(se3_pol_3);
+
+  if(pc_se3_1 != pc_se3_2){
+    std::cout<<"pc_se3_1 and pc_se3_2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(pc_se3_1 != pc_se3_3){
+    std::cout<<"pc_se3_1 and pc_se3_3 should be equals"<<std::endl;
+    error = true;
+  }
+  if(pc_se3_1 == pc_se3_4){
+    std::cout<<"pc_se3_1 and pc_se3_3 should not be equals"<<std::endl;
+    error = true;
+  }
+
+}
+
 int main(int /*argc*/, char** /*argv[]*/) {
   std::cout << "performing tests... \n";
   bool error = false;
@@ -2358,6 +2628,7 @@ int main(int /*argc*/, char** /*argv[]*/) {
   BezierLinearProblemsetup_control_pointsVarCombinatorialEnd(error);
   BezierLinearProblemsetup_control_pointsVarCombinatorialMix(error);
   BezierLinearProblemsetupLoadProblem(error);
+  testOperatorEqual(error);
 
   if (error) {
     std::cout << "There were some errors\n";

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -2334,7 +2334,7 @@ void testOperatorEqual(bool& error){
   polynomial_t polC2_1 = polynomial_t(p0, dp0, ddp0, p1, dp1, ddp1, min, max);
   polynomial_t polC2_2 = polynomial_t(p0, dp0, ddp0, p1, dp1, ddp1, min, max);
   polynomial_t polC2_3(polC2_1);
-
+  //std::cout<<"Should call polynomial method : "<<std::endl;
   if(polC2_1 != polC2_2){
     std::cout<<"polC2_1 and polC2_2 should be equals"<<std::endl;
     error = true;
@@ -2374,6 +2374,7 @@ void testOperatorEqual(bool& error){
   bezier_t::num_t T_max = 3.0;
   bezier_t bc_0(control_points.begin(), control_points.end(), T_min, T_max);
   bezier_t bc_1(bc_0);
+  //std::cout<<"Should call Bezier method : "<<std::endl;
   if(bc_1 != bc_0){
     std::cout<<"bc_0 and bc_1 should be equals"<<std::endl;
     error = true;
@@ -2398,6 +2399,7 @@ void testOperatorEqual(bool& error){
   // test bezier / polynomial
   polynomial_t pol_0 = polynomial_from_curve<polynomial_t>(bc_0);
   CompareCurves<polynomial_t,bezier_t>(pol_0,bc_0,"compare pol_0 and bc_0",error);
+  //std::cout<<"Should call curve_abc method : "<<std::endl;
   if(bc_0 != pol_0){
     std::cout<<"bc_0 and pol_0 should be equals"<<std::endl;
     error = true;
@@ -2426,6 +2428,7 @@ void testOperatorEqual(bool& error){
   ch_control_points2.push_back(pair0);
   ch_control_points2.push_back(pair2);
   cubic_hermite_spline_t chs3(ch_control_points2.begin(), ch_control_points2.end(), time_control_points);
+  //std::cout<<"Should call hermite method : "<<std::endl;
   if(chs0 != chs1){
     std::cout<<"chs0 and chs1 should be equals"<<std::endl;
     error = true;
@@ -2441,6 +2444,7 @@ void testOperatorEqual(bool& error){
 
 //  // test bezier / hermite
   bezier_t bc_ch = bezier_from_curve<bezier_t>(chs0);
+  //std::cout<<"Should call curve_abc method : "<<std::endl;
   if(chs0 != bc_ch){
     std::cout<<"chs0 and bc_ch should be equals"<<std::endl;
     error = true;
@@ -2466,6 +2470,7 @@ void testOperatorEqual(bool& error){
   quaternion_t q2(0.7071, 0., 0.7071, 0);
   q2.normalize();
   SO3Linear_t so3Traj3(q0, q2, tMin, tMax);
+  //std::cout<<"Should call SO3 method : "<<std::endl;
   if(so3Traj1 != so3Traj2){
     std::cout<<"so3Traj1 and so3Traj2 should be equals"<<std::endl;
     error = true;
@@ -2492,18 +2497,22 @@ void testOperatorEqual(bool& error){
   SE3Curve_t se3_bezier3 = SE3Curve_t(translation_bezier, q0.toRotationMatrix(), q2.toRotationMatrix());
   boost::shared_ptr<polynomial_t> translation_polynomial2(new polynomial_t(pol_2));
   SE3Curve_t se3_pol2 = SE3Curve_t(translation_polynomial2, q0.toRotationMatrix(), q1.toRotationMatrix());
+  //std::cout<<"Should call se3 -> curve_abc / so3 method : "<<std::endl;
   if(se3_bezier1 != se3_pol1){
     std::cout<<"se3_bezier1 and se3_pol1 should be equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call se3 -> bezier / so3 method : "<<std::endl;
   if(se3_bezier1 != se3_bezier2){
     std::cout<<"se3_bezier1 and se3_bezier2 should be equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call se3 -> curve_abc / so3 method : "<<std::endl;
   if(se3_bezier1 == se3_pol2){
     std::cout<<"se3_bezier1 and se3_pol2 should not be equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call se3 -> bezier / so3 method : "<<std::endl;
   if(se3_bezier1 == se3_bezier3){
     std::cout<<"se3_bezier1 and se3_bezier3 should not be equals"<<std::endl;
     error = true;
@@ -2535,7 +2544,7 @@ void testOperatorEqual(bool& error){
   piecewise_t pc_C4(bc0_ptr);
   boost::shared_ptr<bezier_t> bc2_ptr(new bezier_t(params0.begin(), params0.end(), 1., 2.));
   pc_C4.add_curve_ptr(bc2_ptr);
-
+  //std::cout<<"Should call curve_abc method : "<<std::endl;
   if(pc_C0 != pc_C1){
     std::cout<<"pc_C0 and pc_C1 should be equals"<<std::endl;
     error = true;

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -1,4 +1,4 @@
-
+#include "curves/fwd.h"
 #include "curves/exact_cubic.h"
 #include "curves/bezier_curve.h"
 #include "curves/polynomial.h"
@@ -20,21 +20,7 @@
 using namespace std;
 
 namespace curves {
-typedef Eigen::Vector3d point3_t;
-typedef Eigen::VectorXd pointX_t;
-typedef Eigen::Matrix<double, 3, 3> matrix3_t;
-typedef Eigen::Quaternion<double> quaternion_t;
-typedef std::vector<pointX_t, Eigen::aligned_allocator<pointX_t> > t_pointX_t;
-typedef curve_abc<double, double, true, pointX_t> curve_abc_t;
-typedef curve_abc<double, double, true, matrix3_t, point3_t> curve_rotation_t;  // templated class used for the rotation (return dimension are fixed)
-typedef boost::shared_ptr<curve_abc_t> curve_ptr_t;
-typedef boost::shared_ptr<curve_rotation_t> curve_rotation_ptr_t;
-typedef polynomial<double, double, true, pointX_t, t_pointX_t> polynomial_t;
-typedef exact_cubic<double, double, true, pointX_t> exact_cubic_t;
 typedef exact_cubic<double, double, true, Eigen::Matrix<double, 1, 1> > exact_cubic_one;
-typedef bezier_curve<double, double, true, pointX_t> bezier_curve_t;
-typedef cubic_hermite_spline<double, double, true, pointX_t> cubic_hermite_spline_t;
-typedef piecewise_curve <double, double, true, pointX_t> piecewise_curve_t;
 typedef exact_cubic_t::spline_constraints spline_constraints_t;
 
 typedef std::pair<double, pointX_t> Waypoint;
@@ -44,9 +30,7 @@ typedef std::pair<double, point_one> WaypointOne;
 typedef std::vector<WaypointOne> T_WaypointOne;
 typedef std::pair<pointX_t, pointX_t> pair_point_tangent_t;
 typedef std::vector<pair_point_tangent_t, Eigen::aligned_allocator<pair_point_tangent_t> > t_pair_point_tangent_t;
-typedef SO3Linear<double, double, true> SO3Linear_t;
-typedef SE3Curve<double, double, true> SE3Curve_t;
-typedef Eigen::Transform<double, 3, Eigen::Affine> transform_t;
+
 
 
 const double margin = 1e-3;

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -145,17 +145,17 @@ void PolynomialCubicFunctionTest(bool& error) {
   }
   // Test derivate and compute_derivative
   // Order 1
-  polynomial_t cf_derivated = cf.compute_derivate(1);
-  ComparePoints(cf.derivate(0, 1), cf_derivated(0), errMsg + " - derivate order 1 : ", error);
-  ComparePoints(cf.derivate(0.3, 1), cf_derivated(0.3), errMsg + " - derivate order 1 : ", error);
-  ComparePoints(cf.derivate(0.5, 1), cf_derivated(0.5), errMsg + " - derivate order 1 : ", error);
-  ComparePoints(cf.derivate(1, 1), cf_derivated(1), errMsg + " - derivate order 1 : ", error);
+  curve_ptr_t cf_derivated = cf.compute_derivate(1);
+  ComparePoints(cf.derivate(0, 1), (*cf_derivated)(0), errMsg + " - derivate order 1 : ", error);
+  ComparePoints(cf.derivate(0.3, 1), (*cf_derivated)(0.3), errMsg + " - derivate order 1 : ", error);
+  ComparePoints(cf.derivate(0.5, 1), (*cf_derivated)(0.5), errMsg + " - derivate order 1 : ", error);
+  ComparePoints(cf.derivate(1, 1), (*cf_derivated)(1), errMsg + " - derivate order 1 : ", error);
   // Order 2
-  polynomial_t cf_derivated_2 = cf.compute_derivate(2);
-  ComparePoints(cf.derivate(0, 2), cf_derivated_2(0), errMsg + " - derivate order 1 : ", error);
-  ComparePoints(cf.derivate(0.3, 2), cf_derivated_2(0.3), errMsg + " - derivate order 1 : ", error);
-  ComparePoints(cf.derivate(0.5, 2), cf_derivated_2(0.5), errMsg + " - derivate order 1 : ", error);
-  ComparePoints(cf.derivate(1, 2), cf_derivated_2(1), errMsg + " - derivate order 1 : ", error);
+  curve_ptr_t cf_derivated_2 = cf.compute_derivate(2);
+  ComparePoints(cf.derivate(0, 2), (*cf_derivated_2)(0), errMsg + " - derivate order 1 : ", error);
+  ComparePoints(cf.derivate(0.3, 2), (*cf_derivated_2)(0.3), errMsg + " - derivate order 1 : ", error);
+  ComparePoints(cf.derivate(0.5, 2), (*cf_derivated_2)(0.5), errMsg + " - derivate order 1 : ", error);
+  ComparePoints(cf.derivate(1, 2), (*cf_derivated_2)(1), errMsg + " - derivate order 1 : ", error);
 }
 
 /*bezier_curve Function tests*/
@@ -197,11 +197,15 @@ void BezierCurveTest(bool& error) {
   // testing bernstein polynomials
   bezier_curve_t cf5(params.begin(), params.end(), 1., 2.);
   std::string errMsg2("In test BezierCurveTest ; Bernstein polynomials do not evaluate as analytical evaluation");
+  boost::shared_ptr<bezier_curve_t> cf5_derivated = boost::dynamic_pointer_cast<bezier_curve_t>(cf5.compute_derivate(1));
+
   for (double d = 1.; d < 2.; d += 0.1) {
     ComparePoints(cf5.evalBernstein(d), cf5(d), errMsg2, error);
     ComparePoints(cf5.evalHorner(d), cf5(d), errMsg2, error);
-    ComparePoints(cf5.compute_derivate(1).evalBernstein(d), cf5.compute_derivate(1)(d), errMsg2, error);
-    ComparePoints(cf5.compute_derivate(1).evalHorner(d), cf5.compute_derivate(1)(d), errMsg2, error);
+    ComparePoints(cf5_derivated->evalBernstein(d), cf5_derivated->operator()(d), errMsg2, error);
+    ComparePoints(cf5_derivated->evalHorner(d), cf5_derivated->operator()(d), errMsg2, error);
+    ComparePoints(cf5.derivate(d,1), cf5_derivated->operator()(d), errMsg2, error);
+
   }
   bool error_in(true);
   try {
@@ -327,7 +331,6 @@ void BezierDerivativeCurveTest(bool& error) {
   params.push_back(b);
   params.push_back(c);
   bezier_curve_t cf3(params.begin(), params.end());
-  ComparePoints(cf3(0), cf3.derivate(0., 0), errMsg, error);
   ComparePoints(cf3(0), cf3.derivate(0., 1), errMsg, error, true);
   ComparePoints(point3_t::Zero(), cf3.derivate(0., 100), errMsg, error);
 }
@@ -480,9 +483,9 @@ void cubicConversionTest(bool& error) {
   CompareCurves<bezier_curve_t, cubic_hermite_spline_t>(bc0, chs2, errMsg1, error);
 
   // Test : compute derivative of bezier => Convert it to polynomial
-  bezier_curve_t bc_der = bc0.compute_derivate(1);
-  polynomial_t pol_test = polynomial_from_curve<polynomial_t>(bc_der);
-  CompareCurves<bezier_curve_t, polynomial_t>(bc_der, pol_test, errMsg1, error);
+  curve_ptr_t bc_der = bc0.compute_derivate(1);
+  polynomial_t pol_test = polynomial_from_curve<polynomial_t>(*bc_der);
+  CompareCurves<curve_abc_t, polynomial_t>(*bc_der, pol_test, errMsg1, error);
 }
 
 /*Exact Cubic Function tests*/
@@ -1191,36 +1194,36 @@ void piecewiseCurveTest(bool& error) {
 
     // compare compute_derivate and derivate results :
 
-//    piecewise_curve_t pc_C2_derivate = pc_C2.compute_derivate(1);
-//    piecewise_curve_t pc_C2_derivate2 = pc_C2.compute_derivate(2);
-//    if (pc_C2.min() != pc_C2_derivate.min()) {
-//      error = true;
-//      std::cout << "min bounds for curve and it's derivate are not equals." << std::endl;
-//    }
-//    if (pc_C2.min() != pc_C2_derivate2.min()) {
-//      error = true;
-//      std::cout << "min bounds for curve and it's second derivate are not equals." << std::endl;
-//    }
-//    if (pc_C2.max() != pc_C2_derivate.max()) {
-//      error = true;
-//      std::cout << "max bounds for curve and it's derivate are not equals." << std::endl;
-//    }
-//    if (pc_C2.max() != pc_C2_derivate2.max()) {
-//      error = true;
-//      std::cout << "max bounds for curve and it's second derivate are not equals." << std::endl;
-//    }
-//    double t = 0.;
-//    while (t < pc_C2.max()) {
-//      if (!QuasiEqual(pc_C2.derivate(t, 1), pc_C2_derivate(t))) {
-//        error = true;
-//        std::cout << "value not equal between derivate and compute_derivate (order 1) at t = " << t << std::endl;
-//      }
-//      if (!QuasiEqual(pc_C2.derivate(t, 2), pc_C2_derivate2(t))) {
-//        error = true;
-//        std::cout << "value not equal between derivate and compute_derivate (order 2) at t = " << t << std::endl;
-//      }
-//      t += 0.01;
-//    }
+    curve_ptr_t pc_C2_derivate = pc_C2.compute_derivate(1);
+    curve_ptr_t pc_C2_derivate2 = pc_C2.compute_derivate(2);
+    if (pc_C2.min() != pc_C2_derivate->min()) {
+      error = true;
+      std::cout << "min bounds for curve and it's derivate are not equals." << std::endl;
+    }
+    if (pc_C2.min() != pc_C2_derivate2->min()) {
+      error = true;
+      std::cout << "min bounds for curve and it's second derivate are not equals." << std::endl;
+    }
+    if (pc_C2.max() != pc_C2_derivate->max()) {
+      error = true;
+      std::cout << "max bounds for curve and it's derivate are not equals." << std::endl;
+    }
+    if (pc_C2.max() != pc_C2_derivate2->max()) {
+      error = true;
+      std::cout << "max bounds for curve and it's second derivate are not equals." << std::endl;
+    }
+    double t = 0.;
+    while (t < pc_C2.max()) {
+      if (!QuasiEqual(pc_C2.derivate(t, 1), (*pc_C2_derivate)(t))) {
+        error = true;
+        std::cout << "value not equal between derivate and compute_derivate (order 1) at t = " << t << std::endl;
+      }
+      if (!QuasiEqual(pc_C2.derivate(t, 2), (*pc_C2_derivate2)(t))) {
+        error = true;
+        std::cout << "value not equal between derivate and compute_derivate (order 2) at t = " << t << std::endl;
+      }
+      t += 0.01;
+    }
 
   } catch (...) {
     error = true;

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -2335,7 +2335,7 @@ int main(int /*argc*/, char** /*argv[]*/) {
   toPolynomialConversionTest(error);
   cubicConversionTest(error);
   curveAbcDimDynamicTest(error);
-  //serializationCurvesTest(error);
+  serializationCurvesTest(error);
   polynomialFromBoundaryConditions(error);
   so3LinearTest(error);
   SO3serializationTest(error);

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -68,7 +68,7 @@ void ComparePoints(const Eigen::MatrixXd& pt1, const Eigen::MatrixXd& pt2, const
 }
 
 template <typename curve1, typename curve2>
-void CompareCurves(curve1 c1, curve2 c2, const std::string& errMsg, bool& error ,double prec = Eigen::NumTraits<double>::dummy_precision()) {
+void CompareCurves(const curve1& c1,const curve2& c2, const std::string& errMsg, bool& error ,double prec = Eigen::NumTraits<double>::dummy_precision()) {
   double T_min = c1.min();
   double T_max = c1.max();
   if (!QuasiEqual(T_min, c2.min()) || !QuasiEqual(T_max, c2.max())) {

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -168,7 +168,7 @@ void BezierCurveTest(bool& error) {
   std::vector<point3_t> params;
   params.push_back(a);
   // 1d curve in [0,1]
-  bezier_curve_t cf1(params.begin(), params.end());
+  bezier_t cf1(params.begin(), params.end());
   point3_t res1;
   res1 = cf1(0);
   point3_t x10 = a;
@@ -177,7 +177,7 @@ void BezierCurveTest(bool& error) {
   ComparePoints(x10, res1, errMsg + "1(1) ", error);
   // 2d curve in [0,1]
   params.push_back(b);
-  bezier_curve_t cf(params.begin(), params.end());
+  bezier_t cf(params.begin(), params.end());
   res1 = cf(0);
   point3_t x20 = a;
   ComparePoints(x20, res1, errMsg + "2(0) ", error);
@@ -186,18 +186,18 @@ void BezierCurveTest(bool& error) {
   ComparePoints(x21, res1, errMsg + "2(1) ", error);
   // 3d curve in [0,1]
   params.push_back(c);
-  bezier_curve_t cf3(params.begin(), params.end());
+  bezier_t cf3(params.begin(), params.end());
   res1 = cf3(0);
   ComparePoints(a, res1, errMsg + "3(0) ", error);
   res1 = cf3(1);
   ComparePoints(c, res1, errMsg + "3(1) ", error);
   // 4d curve in [1,2]
   params.push_back(d);
-  bezier_curve_t cf4(params.begin(), params.end(), 1., 2.);
+  bezier_t cf4(params.begin(), params.end(), 1., 2.);
   // testing bernstein polynomials
-  bezier_curve_t cf5(params.begin(), params.end(), 1., 2.);
+  bezier_t cf5(params.begin(), params.end(), 1., 2.);
   std::string errMsg2("In test BezierCurveTest ; Bernstein polynomials do not evaluate as analytical evaluation");
-  boost::shared_ptr<bezier_curve_t> cf5_derivated = boost::dynamic_pointer_cast<bezier_curve_t>(cf5.compute_derivate(1));
+  boost::shared_ptr<bezier_t> cf5_derivated = boost::dynamic_pointer_cast<bezier_t>(cf5.compute_derivate(1));
 
   for (double d = 1.; d < 2.; d += 0.1) {
     ComparePoints(cf5.evalBernstein(d), cf5(d), errMsg2, error);
@@ -259,7 +259,7 @@ void BezierCurveTestCompareHornerAndBernstein(bool&)  // error
   params.push_back(b);
   params.push_back(c);
   // 3d curve
-  bezier_curve_t cf(params.begin(), params.end());  // defined in [0,1]
+  bezier_t cf(params.begin(), params.end());  // defined in [0,1]
   // Check all evaluation of bezier curve
   clock_t s0, e0, s1, e1, s2, e2, s3, e3;
   s0 = clock();
@@ -294,7 +294,7 @@ void BezierCurveTestCompareHornerAndBernstein(bool&)  // error
   params.push_back(g);
   params.push_back(h);
   params.push_back(i);
-  bezier_curve_t cf2(params.begin(), params.end());
+  bezier_t cf2(params.begin(), params.end());
   s1 = clock();
   for (std::vector<double>::const_iterator cit = values.begin(); cit != values.end(); ++cit) {
     cf2.evalBernstein(*cit);
@@ -330,7 +330,7 @@ void BezierDerivativeCurveTest(bool& error) {
   params.push_back(a);
   params.push_back(b);
   params.push_back(c);
-  bezier_curve_t cf3(params.begin(), params.end());
+  bezier_t cf3(params.begin(), params.end());
   ComparePoints(cf3(0), cf3.derivate(0., 1), errMsg, error, true);
   ComparePoints(point3_t::Zero(), cf3.derivate(0., 100), errMsg, error);
 }
@@ -354,8 +354,8 @@ void BezierDerivativeCurveTimeReparametrizationTest(bool& error) {
   double Tmin = 0.;
   double Tmax = 2.;
   double diffT = Tmax - Tmin;
-  bezier_curve_t cf(params.begin(), params.end());
-  bezier_curve_t cfT(params.begin(), params.end(), Tmin, Tmax);
+  bezier_t cf(params.begin(), params.end());
+  bezier_t cfT(params.begin(), params.end(), Tmin, Tmax);
   ComparePoints(cf(0.5), cfT(1), errMsg, error);
   ComparePoints(cf.derivate(0.5, 1), cfT.derivate(1, 1) * (diffT), errMsg, error);
   ComparePoints(cf.derivate(0.5, 2), cfT.derivate(1, 2) * diffT * diffT, errMsg, error);
@@ -366,7 +366,7 @@ void BezierDerivativeCurveConstraintTest(bool& error) {
   point3_t a(1, 2, 3);
   point3_t b(2, 3, 4);
   point3_t c(3, 4, 5);
-  bezier_curve_t::curve_constraints_t constraints(3);
+  bezier_t::curve_constraints_t constraints(3);
   constraints.init_vel = point3_t(-1, -1, -1);
   constraints.init_acc = point3_t(-2, -2, -2);
   constraints.end_vel = point3_t(-10, -10, -10);
@@ -375,9 +375,9 @@ void BezierDerivativeCurveConstraintTest(bool& error) {
   params.push_back(a);
   params.push_back(b);
   params.push_back(c);
-  bezier_curve_t::num_t T_min = 1.0;
-  bezier_curve_t::num_t T_max = 3.0;
-  bezier_curve_t cf(params.begin(), params.end(), constraints, T_min, T_max);
+  bezier_t::num_t T_min = 1.0;
+  bezier_t::num_t T_max = 3.0;
+  bezier_t cf(params.begin(), params.end(), constraints, T_min, T_max);
   ComparePoints(a, cf(T_min), errMsg0, error);
   ComparePoints(c, cf(T_max), errMsg0, error);
   ComparePoints(constraints.init_vel, cf.derivate(T_min, 1), errMsg0, error);
@@ -421,11 +421,11 @@ void toPolynomialConversionTest(bool& error) {
   control_points.push_back(g);
   control_points.push_back(h);
   control_points.push_back(i);
-  bezier_curve_t::num_t T_min = 1.0;
-  bezier_curve_t::num_t T_max = 3.0;
-  bezier_curve_t bc(control_points.begin(), control_points.end(), T_min, T_max);
+  bezier_t::num_t T_min = 1.0;
+  bezier_t::num_t T_max = 3.0;
+  bezier_t bc(control_points.begin(), control_points.end(), T_min, T_max);
   polynomial_t pol = polynomial_from_curve<polynomial_t>(bc);
-  CompareCurves<polynomial_t, bezier_curve_t>(pol, bc, errMsg, error);
+  CompareCurves<polynomial_t, bezier_t>(pol, bc, errMsg, error);
 }
 
 void cubicConversionTest(bool& error) {
@@ -454,8 +454,8 @@ void cubicConversionTest(bool& error) {
   // hermite to bezier
   // std::cout<<"======================= \n";
   // std::cout<<"hermite to bezier \n";
-  bezier_curve_t bc0 = bezier_from_curve<bezier_curve_t>(chs0);
-  CompareCurves<cubic_hermite_spline_t, bezier_curve_t>(chs0, bc0, errMsg0, error);
+  bezier_t bc0 = bezier_from_curve<bezier_t>(chs0);
+  CompareCurves<cubic_hermite_spline_t, bezier_t>(chs0, bc0, errMsg0, error);
   // hermite to pol
   // std::cout<<"======================= \n";
   // std::cout<<"hermite to polynomial \n";
@@ -469,18 +469,18 @@ void cubicConversionTest(bool& error) {
   // pol to bezier
   // std::cout<<"======================= \n";
   // std::cout<<"polynomial to bezier \n";
-  bezier_curve_t bc1 = bezier_from_curve<bezier_curve_t>(pol0);
-  CompareCurves<bezier_curve_t, polynomial_t>(bc1, pol0, errMsg2, error);
+  bezier_t bc1 = bezier_from_curve<bezier_t>(pol0);
+  CompareCurves<bezier_t, polynomial_t>(bc1, pol0, errMsg2, error);
   // Bezier to pol
   // std::cout<<"======================= \n";
   // std::cout<<"bezier to polynomial \n";
   polynomial_t pol1 = polynomial_from_curve<polynomial_t>(bc0);
-  CompareCurves<bezier_curve_t, polynomial_t>(bc0, pol1, errMsg1, error);
+  CompareCurves<bezier_t, polynomial_t>(bc0, pol1, errMsg1, error);
   // bezier => hermite
   // std::cout<<"======================= \n";
   // std::cout<<"bezier to hermite \n";
   cubic_hermite_spline_t chs2 = hermite_from_curve<cubic_hermite_spline_t>(bc0);
-  CompareCurves<bezier_curve_t, cubic_hermite_spline_t>(bc0, chs2, errMsg1, error);
+  CompareCurves<bezier_t, cubic_hermite_spline_t>(bc0, chs2, errMsg1, error);
 
   // Test : compute derivative of bezier => Convert it to polynomial
   curve_ptr_t bc_der = bc0.compute_derivate(1);
@@ -847,7 +847,7 @@ void BezierEvalDeCasteljau(bool& error) {
   params.push_back(b);
   params.push_back(c);
   // 3d curve
-  bezier_curve_t cf(params.begin(), params.end());
+  bezier_t cf(params.begin(), params.end());
   std::string errmsg("Error in BezierEvalDeCasteljau; while comparing actual bezier evaluation and de Casteljau : ");
   for (std::vector<double>::const_iterator cit = values.begin(); cit != values.end(); ++cit) {
     ComparePoints(cf.evalDeCasteljau(*cit), cf(*cit), errmsg, error);
@@ -858,7 +858,7 @@ void BezierEvalDeCasteljau(bool& error) {
   params.push_back(g);
   params.push_back(h);
   params.push_back(i);
-  bezier_curve_t cf2(params.begin(), params.end());
+  bezier_t cf2(params.begin(), params.end());
   for (std::vector<double>::const_iterator cit = values.begin(); cit != values.end(); ++cit) {
     ComparePoints(cf.evalDeCasteljau(*cit), cf(*cit), errmsg, error);
   }
@@ -894,8 +894,8 @@ void BezierSplitCurve(bool& error) {
     double t0 = (rand() / (double)RAND_MAX) * (t_max - t_min) + t_min;
     double t1 = (rand() / (double)RAND_MAX) * (t_max - t0) + t0;
     double ts = (rand() / (double)RAND_MAX) * (t1 - t0) + t0;
-    bezier_curve_t c(wps.begin(), wps.end(), t0, t1);
-    std::pair<bezier_curve_t, bezier_curve_t> cs = c.split(ts);
+    bezier_t c(wps.begin(), wps.end(), t0, t1);
+    std::pair<bezier_t, bezier_t> cs = c.split(ts);
     // test on splitted curves :
     if (!((c.degree_ == cs.first.degree_) && (c.degree_ == cs.second.degree_))) {
       error = true;
@@ -925,19 +925,19 @@ void BezierSplitCurve(bool& error) {
       ti += 0.01;
     }
     // Test extract function
-    bezier_curve_t bezier_extracted0 = c.extract(t0 + 0.01, t1 - 0.01);  // T_min < t0 < t1 < T_max
+    bezier_t bezier_extracted0 = c.extract(t0 + 0.01, t1 - 0.01);  // T_min < t0 < t1 < T_max
     for (double t = bezier_extracted0.min(); t < bezier_extracted0.max(); t += 0.01) {
       ComparePoints(bezier_extracted0(t), c(t), errMsg6, error);
     }
-    bezier_curve_t bezier_extracted1 = c.extract(t0, t1 - 0.01);  // T_min = t0 < t1 < T_max
+    bezier_t bezier_extracted1 = c.extract(t0, t1 - 0.01);  // T_min = t0 < t1 < T_max
     for (double t = bezier_extracted1.min(); t < bezier_extracted1.max(); t += 0.01) {
       ComparePoints(bezier_extracted1(t), c(t), errMsg6, error);
     }
-    bezier_curve_t bezier_extracted2 = c.extract(t0 + 0.01, t1);  // T_min < t0 < t1 = T_max
+    bezier_t bezier_extracted2 = c.extract(t0 + 0.01, t1);  // T_min < t0 < t1 = T_max
     for (double t = bezier_extracted2.min(); t < bezier_extracted2.max(); t += 0.01) {
       ComparePoints(bezier_extracted2(t), c(t), errMsg6, error);
     }
-    bezier_curve_t bezier_extracted3 = c.extract(t0, t1);  // T_min = t0 < t1 = T_max
+    bezier_t bezier_extracted3 = c.extract(t0, t1);  // T_min = t0 < t1 = T_max
     for (double t = bezier_extracted3.min(); t < bezier_extracted3.max(); t += 0.01) {
       ComparePoints(bezier_extracted3(t), c(t), errMsg6, error);
     }
@@ -1059,7 +1059,7 @@ void piecewiseCurveTest(bool& error) {
     boost::shared_ptr<polynomial_t> pol2_ptr (new polynomial_t(vec2.begin(), vec2.end(), 1, 2));
     boost::shared_ptr<polynomial_t> pol3_ptr (new polynomial_t(vec3.begin(), vec3.end(), 2, 3));
     // 1 polynomial in curve
-    piecewise_curve_t pc(pol1_ptr);
+    piecewise_t pc(pol1_ptr);
     res = pc(0.5);
     ComparePoints(a, res, errmsg1, error);
     // 3 polynomials in curve
@@ -1096,9 +1096,9 @@ void piecewiseCurveTest(bool& error) {
     params1.push_back(c0);
     params1.push_back(b0);
     params1.push_back(a0);
-    boost::shared_ptr<bezier_curve_t> bc0_ptr(new bezier_curve_t(params0.begin(), params0.end(), 0., 1.));
-    boost::shared_ptr<bezier_curve_t> bc1_ptr(new bezier_curve_t(params1.begin(), params1.end(), 1., 2.));
-    piecewise_curve_t pc_C0(bc0_ptr);
+    boost::shared_ptr<bezier_t> bc0_ptr(new bezier_t(params0.begin(), params0.end(), 0., 1.));
+    boost::shared_ptr<bezier_t> bc1_ptr(new bezier_t(params1.begin(), params1.end(), 1., 2.));
+    piecewise_t pc_C0(bc0_ptr);
     pc_C0.add_curve_ptr(bc1_ptr);
     // Check value in t=0.5 and t=1.5
     res = pc_C0(0.0);
@@ -1127,7 +1127,7 @@ void piecewiseCurveTest(bool& error) {
     time_control_points1.push_back(3.);  // hermite 1 between [1,3]
     boost::shared_ptr<cubic_hermite_spline_t> chs0_ptr(new cubic_hermite_spline_t(control_points_0.begin(), control_points_0.end(), time_control_points0));
     boost::shared_ptr<cubic_hermite_spline_t> chs1_ptr(new cubic_hermite_spline_t(control_points_1.begin(), control_points_1.end(), time_control_points1));
-    piecewise_curve_t pc_C1(chs0_ptr);
+    piecewise_t pc_C1(chs0_ptr);
     pc_C1.add_curve_ptr(chs1_ptr);
     // Create piecewise curve C2
     point3_t a1(0, 0, 0);
@@ -1141,7 +1141,7 @@ void piecewiseCurveTest(bool& error) {
     vecb.push_back(b1);  // x=(t-1)+1, y=(t-1)+1, z=(t-1)+1
     boost::shared_ptr<polynomial_t> pola_ptr(new polynomial_t(veca.begin(), veca.end(), 0, 1));
     boost::shared_ptr<polynomial_t> polb_ptr(new polynomial_t(vecb.begin(), vecb.end(), 1, 2));
-    piecewise_curve_t pc_C2(pola_ptr);
+    piecewise_t pc_C2(pola_ptr);
     pc_C2.add_curve_ptr(polb_ptr);
     // check C0 continuity
     std::string errmsg2("in piecewise polynomial curve test, Error while checking continuity C0 on ");
@@ -1185,12 +1185,12 @@ void piecewiseCurveTest(bool& error) {
     }
     // CONVERT PIECEWISE POLYNOMIAL CURVES TO BEZIER AND HERMITE
     std::string errmsg5("in piecewise polynomial curve test, Error while checking piecewise curve conversion");
-    piecewise_curve_t pc_bezier = pc.convert_piecewise_curve_to_bezier<bezier_curve_t>();
-    CompareCurves<piecewise_curve_t, piecewise_curve_t>(pc, pc_bezier, errmsg5, error);
-    piecewise_curve_t pc_hermite = pc.convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>();
-    CompareCurves<piecewise_curve_t, piecewise_curve_t>(pc, pc_hermite, errmsg5, error);
-    piecewise_curve_t pc_polynomial_same = pc.convert_piecewise_curve_to_polynomial<polynomial_t>();
-    CompareCurves<piecewise_curve_t, piecewise_curve_t>(pc, pc_polynomial_same, errmsg5, error);
+    piecewise_t pc_bezier = pc.convert_piecewise_curve_to_bezier<bezier_t>();
+    CompareCurves<piecewise_t, piecewise_t>(pc, pc_bezier, errmsg5, error);
+    piecewise_t pc_hermite = pc.convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>();
+    CompareCurves<piecewise_t, piecewise_t>(pc, pc_hermite, errmsg5, error);
+    piecewise_t pc_polynomial_same = pc.convert_piecewise_curve_to_polynomial<polynomial_t>();
+    CompareCurves<piecewise_t, piecewise_t>(pc, pc_polynomial_same, errmsg5, error);
 
     // compare compute_derivate and derivate results :
 
@@ -1236,7 +1236,7 @@ void curveAbcDimDynamicTest(bool& error) {
   typedef polynomial<double, double, true> polynomial_test_t;
   typedef exact_cubic<double, double, true> exact_cubic_test_t;
   typedef exact_cubic_test_t::spline_constraints spline_constraints_test_t;
-  typedef bezier_curve<double, double, true> bezier_curve_test_t;
+  typedef bezier_curve<double, double, true> bezier_test_t;
   typedef cubic_hermite_spline<double, double, true> cubic_hermite_spline_test_t;
   curve_abc_test_t* pt_curve_abc;
   // POLYNOMIAL
@@ -1253,7 +1253,7 @@ void curveAbcDimDynamicTest(bool& error) {
     error = false;
   }
   // BEZIER
-  bezier_curve_test_t bc = bezier_from_curve<bezier_curve_test_t>(pol);
+  bezier_test_t bc = bezier_from_curve<bezier_test_t>(pol);
   try {
     bc(0);
     bc(1);
@@ -1347,7 +1347,7 @@ void PiecewisePolynomialCurveFromDiscretePoints(bool& error) {
   time_points.push_back(t3);
 
   // Piecewise polynomial curve C0 => Linear interpolation between points
-  piecewise_curve_t ppc_C0 =  piecewise_curve_t::
+  piecewise_t ppc_C0 =  piecewise_t::
     convert_discrete_points_to_polynomial<polynomial_t>(points,time_points);
   if (!ppc_C0.is_continuous(0))
   {
@@ -1362,7 +1362,7 @@ void PiecewisePolynomialCurveFromDiscretePoints(bool& error) {
   ComparePoints(pos_between_po_and_p1, ppc_C0(time_between_po_and_p1), errMsg, error);
 
   // Piecewise polynomial curve C1
-  piecewise_curve_t ppc_C1 =  piecewise_curve_t::
+  piecewise_t ppc_C1 =  piecewise_t::
     convert_discrete_points_to_polynomial<polynomial_t>(points,
                                                         points_derivative,
                                                         time_points);
@@ -1377,7 +1377,7 @@ void PiecewisePolynomialCurveFromDiscretePoints(bool& error) {
   }
 
   // Piecewise polynomial curve C2
-  piecewise_curve_t ppc_C2 =  piecewise_curve_t::
+  piecewise_t ppc_C2 =  piecewise_t::
     convert_discrete_points_to_polynomial<polynomial_t>(points,
                                                         points_derivative,
                                                         points_second_derivative,
@@ -1414,7 +1414,7 @@ void serializationCurvesTest(bool& error) {
     polynomial_t pol1(vec1.begin(), vec1.end(), 0, 1);
     polynomial_t pol2(vec2.begin(), vec2.end(), 1, 2);
     polynomial_t pol3(vec3.begin(), vec3.end(), 2, 3);
-    piecewise_curve_t ppc;
+    piecewise_t ppc;
     ppc.add_curve<polynomial_t>(pol1);
     ppc.add_curve<polynomial_t>(pol2);
     ppc.add_curve<polynomial_t>(pol3);
@@ -1427,11 +1427,11 @@ void serializationCurvesTest(bool& error) {
     pol_test.loadFromText<polynomial_t>(fileName1);
     CompareCurves<polynomial_t, polynomial_t>(pol1, pol_test, errMsg1, error);
     // Test serialization on Bezier
-    bezier_curve_t bc = bezier_from_curve<bezier_curve_t>(pol1);
-    bc.saveAsText<bezier_curve_t>(fileName);
-    bezier_curve_t bc_test;
-    bc_test.loadFromText<bezier_curve_t>(fileName);
-    CompareCurves<polynomial_t, bezier_curve_t>(pol1, bc_test, errMsg2, error);
+    bezier_t bc = bezier_from_curve<bezier_t>(pol1);
+    bc.saveAsText<bezier_t>(fileName);
+    bezier_t bc_test;
+    bc_test.loadFromText<bezier_t>(fileName);
+    CompareCurves<polynomial_t, bezier_t>(pol1, bc_test, errMsg2, error);
     // Test serialization on Cubic Hermite
     cubic_hermite_spline_t chs = hermite_from_curve<cubic_hermite_spline_t>(pol1);
     chs.saveAsText<cubic_hermite_spline_t>(fileName);
@@ -1440,26 +1440,26 @@ void serializationCurvesTest(bool& error) {
     CompareCurves<polynomial_t, cubic_hermite_spline_t>(pol1, chs_test, errMsg3, error);
     // Piecewise curves
     // Test serialization on Piecewise Polynomial curve
-    ppc.saveAsText<piecewise_curve_t>(fileName);
-    piecewise_curve_t ppc_test,ppc_test_binary;
-    ppc_test.loadFromText<piecewise_curve_t>(fileName);
-    CompareCurves<piecewise_curve_t, piecewise_curve_t>(ppc, ppc_test, errMsg4, error);
-    ppc.saveAsBinary<piecewise_curve_t>(fileName);
-    ppc_test_binary.loadFromBinary<piecewise_curve_t>(fileName);
-    CompareCurves<piecewise_curve_t, piecewise_curve_t>(ppc, ppc_test_binary, errMsg4, error);
+    ppc.saveAsText<piecewise_t>(fileName);
+    piecewise_t ppc_test,ppc_test_binary;
+    ppc_test.loadFromText<piecewise_t>(fileName);
+    CompareCurves<piecewise_t, piecewise_t>(ppc, ppc_test, errMsg4, error);
+    ppc.saveAsBinary<piecewise_t>(fileName);
+    ppc_test_binary.loadFromBinary<piecewise_t>(fileName);
+    CompareCurves<piecewise_t, piecewise_t>(ppc, ppc_test_binary, errMsg4, error);
 
     // Test serialization on Piecewise Bezier curve
-    piecewise_curve_t pbc = ppc.convert_piecewise_curve_to_bezier<bezier_curve_t>();
-    pbc.saveAsText<piecewise_curve_t>(fileName);
-    piecewise_curve_t pbc_test;
-    pbc_test.loadFromText<piecewise_curve_t>(fileName);
-    CompareCurves<piecewise_curve_t, piecewise_curve_t>(ppc, pbc_test, errMsg4, error);
+    piecewise_t pbc = ppc.convert_piecewise_curve_to_bezier<bezier_t>();
+    pbc.saveAsText<piecewise_t>(fileName);
+    piecewise_t pbc_test;
+    pbc_test.loadFromText<piecewise_t>(fileName);
+    CompareCurves<piecewise_t, piecewise_t>(ppc, pbc_test, errMsg4, error);
     // Test serialization on Piecewise Cubic Hermite curve
-    piecewise_curve_t pchc = ppc.convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>();
-    pchc.saveAsText<piecewise_curve_t>(fileName);
-    piecewise_curve_t pchc_test;
-    pchc_test.loadFromText<piecewise_curve_t>(fileName);
-    CompareCurves<piecewise_curve_t, piecewise_curve_t>(ppc, pchc_test, errMsg4, error);
+    piecewise_t pchc = ppc.convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>();
+    pchc.saveAsText<piecewise_t>(fileName);
+    piecewise_t pchc_test;
+    pchc_test.loadFromText<piecewise_t>(fileName);
+    CompareCurves<piecewise_t, piecewise_t>(ppc, pchc_test, errMsg4, error);
     // Test serialization on exact cubic
     curves::T_Waypoint waypoints;
     for (double i = 0; i <= 1; i = i + 0.2) {
@@ -1488,13 +1488,13 @@ void serializationCurvesTest(bool& error) {
     // Piecewise Polynomial
     pt_0 = NULL;
     pt_1 = NULL;
-    ppc_test = piecewise_curve_t();
+    ppc_test = piecewise_t();
     pt_0 = &ppc;
     pt_1 = &ppc_test;
-    (*pt_0).saveAsText<piecewise_curve_t>(fileName);
-    (*pt_1).loadFromText<piecewise_curve_t>(fileName);
-    CompareCurves<piecewise_curve_t, piecewise_curve_t>(
-        ppc, (*dynamic_cast<piecewise_curve_t*>(pt_1)), errMsg6, error);
+    (*pt_0).saveAsText<piecewise_t>(fileName);
+    (*pt_1).loadFromText<piecewise_t>(fileName);
+    CompareCurves<piecewise_t, piecewise_t>(
+        ppc, (*dynamic_cast<piecewise_t*>(pt_1)), errMsg6, error);
   } catch (...) {
     error = true;
     std::cout << "Error in serializationCurvesTest" << std::endl;
@@ -1778,7 +1778,7 @@ void se3CurveTest(bool& error) {
     params.push_back(b);
     params.push_back(c);
     params.push_back(d);
-    boost::shared_ptr<bezier_curve_t> translation_bezier(new bezier_curve_t(params.begin(), params.end(), min, max));
+    boost::shared_ptr<bezier_t> translation_bezier(new bezier_t(params.begin(), params.end(), min, max));
     cBezier = SE3Curve_t(translation_bezier, q0.toRotationMatrix(), q1.toRotationMatrix());
     p0 = (*translation_bezier)(min);
     p1 = (*translation_bezier)(max);
@@ -1916,7 +1916,7 @@ void Se3serializationTest(bool &error){
     params.push_back(b);
     params.push_back(c);
     params.push_back(d);
-    boost::shared_ptr<bezier_curve_t> translation_bezier(new bezier_curve_t(params.begin(), params.end(), min, max));
+    boost::shared_ptr<bezier_t> translation_bezier(new bezier_t(params.begin(), params.end(), min, max));
     cBezier = SE3Curve_t(translation_bezier, q0, q1);
   }
 

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -145,13 +145,13 @@ void PolynomialCubicFunctionTest(bool& error) {
   }
   // Test derivate and compute_derivative
   // Order 1
-  curve_ptr_t cf_derivated = cf.compute_derivate(1);
+  curve_abc_t* cf_derivated = cf.compute_derivate(1);
   ComparePoints(cf.derivate(0, 1), (*cf_derivated)(0), errMsg + " - derivate order 1 : ", error);
   ComparePoints(cf.derivate(0.3, 1), (*cf_derivated)(0.3), errMsg + " - derivate order 1 : ", error);
   ComparePoints(cf.derivate(0.5, 1), (*cf_derivated)(0.5), errMsg + " - derivate order 1 : ", error);
   ComparePoints(cf.derivate(1, 1), (*cf_derivated)(1), errMsg + " - derivate order 1 : ", error);
   // Order 2
-  curve_ptr_t cf_derivated_2 = cf.compute_derivate(2);
+  curve_abc_t* cf_derivated_2 = cf.compute_derivate(2);
   ComparePoints(cf.derivate(0, 2), (*cf_derivated_2)(0), errMsg + " - derivate order 1 : ", error);
   ComparePoints(cf.derivate(0.3, 2), (*cf_derivated_2)(0.3), errMsg + " - derivate order 1 : ", error);
   ComparePoints(cf.derivate(0.5, 2), (*cf_derivated_2)(0.5), errMsg + " - derivate order 1 : ", error);
@@ -197,7 +197,7 @@ void BezierCurveTest(bool& error) {
   // testing bernstein polynomials
   bezier_t cf5(params.begin(), params.end(), 1., 2.);
   std::string errMsg2("In test BezierCurveTest ; Bernstein polynomials do not evaluate as analytical evaluation");
-  boost::shared_ptr<bezier_t> cf5_derivated = boost::dynamic_pointer_cast<bezier_t>(cf5.compute_derivate(1));
+  bezier_t* cf5_derivated = cf5.compute_derivate(1);
 
   for (double d = 1.; d < 2.; d += 0.1) {
     ComparePoints(cf5.evalBernstein(d), cf5(d), errMsg2, error);
@@ -483,7 +483,7 @@ void cubicConversionTest(bool& error) {
   CompareCurves<bezier_t, cubic_hermite_spline_t>(bc0, chs2, errMsg1, error);
 
   // Test : compute derivative of bezier => Convert it to polynomial
-  curve_ptr_t bc_der = bc0.compute_derivate(1);
+  curve_abc_t* bc_der = bc0.compute_derivate(1);
   polynomial_t pol_test = polynomial_from_curve<polynomial_t>(*bc_der);
   CompareCurves<curve_abc_t, polynomial_t>(*bc_der, pol_test, errMsg1, error);
 }
@@ -1194,8 +1194,8 @@ void piecewiseCurveTest(bool& error) {
 
     // compare compute_derivate and derivate results :
 
-    curve_ptr_t pc_C2_derivate = pc_C2.compute_derivate(1);
-    curve_ptr_t pc_C2_derivate2 = pc_C2.compute_derivate(2);
+    curve_abc_t* pc_C2_derivate = pc_C2.compute_derivate(1);
+    curve_abc_t* pc_C2_derivate2 = pc_C2.compute_derivate(2);
     if (pc_C2.min() != pc_C2_derivate->min()) {
       error = true;
       std::cout << "min bounds for curve and it's derivate are not equals." << std::endl;

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -1191,6 +1191,15 @@ void piecewiseCurveTest(bool& error) {
     CompareCurves<piecewise_t, piecewise_t>(pc, pc_hermite, errmsg5, error);
     piecewise_t pc_polynomial_same = pc.convert_piecewise_curve_to_polynomial<polynomial_t>();
     CompareCurves<piecewise_t, piecewise_t>(pc, pc_polynomial_same, errmsg5, error);
+    // CONVERT PIECEWISE BEZIER TO POLYNOMIAL AND HERMITE
+
+    std::string errmsg6("in piecewise bezier curve test, Error while checking piecewise curve conversion");
+    piecewise_t pc_bezier1 = pc_C0.convert_piecewise_curve_to_bezier<bezier_t>();
+    CompareCurves<piecewise_t, piecewise_t>(pc_C0, pc_bezier1, errmsg6, error);
+    piecewise_t pc_hermite1 = pc_C0.convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>();
+    CompareCurves<piecewise_t, piecewise_t>(pc_C0, pc_hermite1, errmsg6, error);
+    piecewise_t pc_polynomial1 = pc_C0.convert_piecewise_curve_to_polynomial<polynomial_t>();
+    CompareCurves<piecewise_t, piecewise_t>(pc_C0, pc_polynomial1, errmsg6, error);
 
     // compare compute_derivate and derivate results :
 

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -437,7 +437,7 @@ void toPolynomialConversionTest(bool& error) {
   bezier_curve_t::num_t T_min = 1.0;
   bezier_curve_t::num_t T_max = 3.0;
   bezier_curve_t bc(control_points.begin(), control_points.end(), T_min, T_max);
-  polynomial_t pol = polynomial_from_curve<polynomial_t, bezier_curve_t>(bc);
+  polynomial_t pol = polynomial_from_curve<polynomial_t>(bc);
   CompareCurves<polynomial_t, bezier_curve_t>(pol, bc, errMsg, error);
 }
 
@@ -467,37 +467,37 @@ void cubicConversionTest(bool& error) {
   // hermite to bezier
   // std::cout<<"======================= \n";
   // std::cout<<"hermite to bezier \n";
-  bezier_curve_t bc0 = bezier_from_curve<bezier_curve_t, cubic_hermite_spline_t>(chs0);
+  bezier_curve_t bc0 = bezier_from_curve<bezier_curve_t>(chs0);
   CompareCurves<cubic_hermite_spline_t, bezier_curve_t>(chs0, bc0, errMsg0, error);
   // hermite to pol
   // std::cout<<"======================= \n";
   // std::cout<<"hermite to polynomial \n";
-  polynomial_t pol0 = polynomial_from_curve<polynomial_t, cubic_hermite_spline_t>(chs0);
+  polynomial_t pol0 = polynomial_from_curve<polynomial_t>(chs0);
   CompareCurves<cubic_hermite_spline_t, polynomial_t>(chs0, pol0, errMsg0, error);
   // pol to hermite
   // std::cout<<"======================= \n";
   // std::cout<<"polynomial to hermite \n";
-  cubic_hermite_spline_t chs1 = hermite_from_curve<cubic_hermite_spline_t, polynomial_t>(pol0);
+  cubic_hermite_spline_t chs1 = hermite_from_curve<cubic_hermite_spline_t>(pol0);
   CompareCurves<polynomial_t, cubic_hermite_spline_t>(pol0, chs1, errMsg2, error);
   // pol to bezier
   // std::cout<<"======================= \n";
   // std::cout<<"polynomial to bezier \n";
-  bezier_curve_t bc1 = bezier_from_curve<bezier_curve_t, polynomial_t>(pol0);
+  bezier_curve_t bc1 = bezier_from_curve<bezier_curve_t>(pol0);
   CompareCurves<bezier_curve_t, polynomial_t>(bc1, pol0, errMsg2, error);
   // Bezier to pol
   // std::cout<<"======================= \n";
   // std::cout<<"bezier to polynomial \n";
-  polynomial_t pol1 = polynomial_from_curve<polynomial_t, bezier_curve_t>(bc0);
+  polynomial_t pol1 = polynomial_from_curve<polynomial_t>(bc0);
   CompareCurves<bezier_curve_t, polynomial_t>(bc0, pol1, errMsg1, error);
   // bezier => hermite
   // std::cout<<"======================= \n";
   // std::cout<<"bezier to hermite \n";
-  cubic_hermite_spline_t chs2 = hermite_from_curve<cubic_hermite_spline_t, bezier_curve_t>(bc0);
+  cubic_hermite_spline_t chs2 = hermite_from_curve<cubic_hermite_spline_t>(bc0);
   CompareCurves<bezier_curve_t, cubic_hermite_spline_t>(bc0, chs2, errMsg1, error);
 
   // Test : compute derivative of bezier => Convert it to polynomial
   bezier_curve_t bc_der = bc0.compute_derivate(1);
-  polynomial_t pol_test = polynomial_from_curve<polynomial_t, bezier_curve_t>(bc_der);
+  polynomial_t pol_test = polynomial_from_curve<polynomial_t>(bc_der);
   CompareCurves<bezier_curve_t, polynomial_t>(bc_der, pol_test, errMsg1, error);
 }
 
@@ -1197,13 +1197,13 @@ void piecewiseCurveTest(bool& error) {
       error = true;
     }
     // CONVERT PIECEWISE POLYNOMIAL CURVES TO BEZIER AND HERMITE
-//    std::string errmsg5("in piecewise polynomial curve test, Error while checking piecewise curve conversion");
-//    piecewise_curve_t pc_bezier = pc.convert_piecewise_curve_to_bezier<bezier_curve_t>();
-//    CompareCurves<piecewise_curve_t, piecewise_curve_t>(pc, pc_bezier, errmsg5, error);
-//    piecewise_curve_t pc_hermite = pc.convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>();
-//    CompareCurves<piecewise_curve_t, piecewise_curve_t>(pc, pc_hermite, errmsg5, error);
-//    piecewise_curve_t pc_polynomial_same = pc.convert_piecewise_curve_to_polynomial<polynomial_t>();
-//    CompareCurves<piecewise_curve_t, piecewise_curve_t>(pc, pc_polynomial_same, errmsg5, error);
+    std::string errmsg5("in piecewise polynomial curve test, Error while checking piecewise curve conversion");
+    piecewise_curve_t pc_bezier = pc.convert_piecewise_curve_to_bezier<bezier_curve_t>();
+    CompareCurves<piecewise_curve_t, piecewise_curve_t>(pc, pc_bezier, errmsg5, error);
+    piecewise_curve_t pc_hermite = pc.convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>();
+    CompareCurves<piecewise_curve_t, piecewise_curve_t>(pc, pc_hermite, errmsg5, error);
+    piecewise_curve_t pc_polynomial_same = pc.convert_piecewise_curve_to_polynomial<polynomial_t>();
+    CompareCurves<piecewise_curve_t, piecewise_curve_t>(pc, pc_polynomial_same, errmsg5, error);
 
     // compare compute_derivate and derivate results :
 
@@ -1266,7 +1266,7 @@ void curveAbcDimDynamicTest(bool& error) {
     error = false;
   }
   // BEZIER
-  bezier_curve_test_t bc = bezier_from_curve<bezier_curve_test_t, polynomial_test_t>(pol);
+  bezier_curve_test_t bc = bezier_from_curve<bezier_curve_test_t>(pol);
   try {
     bc(0);
     bc(1);
@@ -1274,7 +1274,7 @@ void curveAbcDimDynamicTest(bool& error) {
     error = false;
   }
   // CUBIC HERMITE
-  cubic_hermite_spline_test_t chs = hermite_from_curve<cubic_hermite_spline_test_t, polynomial_test_t>(pol);
+  cubic_hermite_spline_test_t chs = hermite_from_curve<cubic_hermite_spline_test_t>(pol);
   try {
     chs(0);
     chs(1);
@@ -1440,13 +1440,13 @@ void serializationCurvesTest(bool& error) {
     pol_test.loadFromText<polynomial_t>(fileName1);
     CompareCurves<polynomial_t, polynomial_t>(pol1, pol_test, errMsg1, error);
     // Test serialization on Bezier
-    bezier_curve_t bc = bezier_from_curve<bezier_curve_t, polynomial_t>(pol1);
+    bezier_curve_t bc = bezier_from_curve<bezier_curve_t>(pol1);
     bc.saveAsText<bezier_curve_t>(fileName);
     bezier_curve_t bc_test;
     bc_test.loadFromText<bezier_curve_t>(fileName);
     CompareCurves<polynomial_t, bezier_curve_t>(pol1, bc_test, errMsg2, error);
     // Test serialization on Cubic Hermite
-    cubic_hermite_spline_t chs = hermite_from_curve<cubic_hermite_spline_t, polynomial_t>(pol1);
+    cubic_hermite_spline_t chs = hermite_from_curve<cubic_hermite_spline_t>(pol1);
     chs.saveAsText<cubic_hermite_spline_t>(fileName);
     cubic_hermite_spline_t chs_test;
     chs_test.loadFromText<cubic_hermite_spline_t>(fileName);
@@ -1462,17 +1462,17 @@ void serializationCurvesTest(bool& error) {
     CompareCurves<piecewise_curve_t, piecewise_curve_t>(ppc, ppc_test_binary, errMsg4, error);
 
     // Test serialization on Piecewise Bezier curve
-//    piecewise_curve_t pbc = ppc.convert_piecewise_curve_to_bezier<bezier_curve_t>();
-//    pbc.saveAsText<piecewise_curve_t>(fileName);
-//    piecewise_curve_t pbc_test;
-//    pbc_test.loadFromText<piecewise_curve_t>(fileName);
-//    CompareCurves<piecewise_curve_t, piecewise_curve_t>(ppc, pbc_test, errMsg4, error);
-//    // Test serialization on Piecewise Cubic Hermite curve
-//    piecewise_curve_t pchc = ppc.convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>();
-//    pchc.saveAsText<piecewise_curve_t>(fileName);
-//    piecewise_curve_t pchc_test;
-//    pchc_test.loadFromText<piecewise_curve_t>(fileName);
-//    CompareCurves<piecewise_curve_t, piecewise_curve_t>(ppc, pchc_test, errMsg4, error);
+    piecewise_curve_t pbc = ppc.convert_piecewise_curve_to_bezier<bezier_curve_t>();
+    pbc.saveAsText<piecewise_curve_t>(fileName);
+    piecewise_curve_t pbc_test;
+    pbc_test.loadFromText<piecewise_curve_t>(fileName);
+    CompareCurves<piecewise_curve_t, piecewise_curve_t>(ppc, pbc_test, errMsg4, error);
+    // Test serialization on Piecewise Cubic Hermite curve
+    piecewise_curve_t pchc = ppc.convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>();
+    pchc.saveAsText<piecewise_curve_t>(fileName);
+    piecewise_curve_t pchc_test;
+    pchc_test.loadFromText<piecewise_curve_t>(fileName);
+    CompareCurves<piecewise_curve_t, piecewise_curve_t>(ppc, pchc_test, errMsg4, error);
     // Test serialization on exact cubic
     curves::T_Waypoint waypoints;
     for (double i = 0; i <= 1; i = i + 0.2) {

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -2389,6 +2389,24 @@ void testOperatorEqual(bool& error){
     std::cout<<"bc_0 and bc_2 should not be equals"<<std::endl;
     error = true;
   }
+
+  point3_t e3(3, 61.9, 7);
+  point3_t g3(-3, 36, 7);
+  std::vector<point3_t> control_points3;
+  control_points3.push_back(a);
+  control_points3.push_back(b);
+  control_points3.push_back(c);
+  control_points3.push_back(d);
+  control_points3.push_back(e3);
+  control_points3.push_back(f);
+  control_points3.push_back(g3);
+  control_points3.push_back(h);
+  control_points3.push_back(i);
+  bezier_t bc_0_3(control_points3.begin(), control_points3.end(), T_min, T_max);
+  if(bc_0_3 == bc_0){
+   std::cout<<"bc_0_3 and bc_0 should not be equals"<<std::endl;
+   error = true;
+  }
   polynomial_t pol_2 = polynomial_from_curve<polynomial_t>(bc_2);
   bezier_t bc_3 = bezier_from_curve<bezier_t>(pol_2);
   if(bc_2 != bc_3){


### PR DESCRIPTION
Solve issue https://gepgitlab.laas.fr/loco-3d/curves/issues/28

This PR add the method `isApprox` and the operator `==` and `!=` to `curve_abc` and reimplement it in most of the child class. 
The operator `==` in `curve_abc` check if two generic curves are equal **by value** ie. if the evaluate and derivate method of both curves return the same value along all the curve (using discretization). 
In the child class, the operator `==` check exactly if the two curves of the same type are the same (ie. by checking the coefficients values in a polynomial or the control points in a Bezier).

This choice of implementing a generic equality test between any kind of curves was made because two curves could represent the exact same trajectory using two different formulations (see the unit tests). But maybe this kind of curves should not be considered as _equal_ and this test should only be done in the  `isApprox` method ? 



This PR also add the python binding of the operator `==` and `!=` and unit tests in C++ and Python.

 
