### PR TITLE
Topic/operator equal

### DIFF
--- a/include/curves/bernstein.h
+++ b/include/curves/bernstein.h
@@ -45,6 +45,17 @@ struct Bern {
     return bin_m_i_ * (pow(u, i_)) * pow((1 - u), m_minus_i);
   }
 
+  virtual bool operator== (const Bern& other) const{
+    return m_minus_i == other.m_minus_i
+        && i_ == other.i_
+        && bin_m_i_ == other.bin_m_i_;
+  }
+
+  virtual bool operator!=(const Bern& other) const {
+    return !(*this == other);
+  }
+
+
   /* Attributes */
   Numeric m_minus_i;
   Numeric i_;

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -148,7 +148,6 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
    * @return true is the two curves are approximately equals
    */
   bool isApprox(const bezier_curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
-    std::cout<<"is approx in bezier called."<<std::endl;
     bool equal = T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -140,6 +140,30 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
     }
   }
 
+  virtual bool operator==(const bezier_curve_t& other) const {
+    //std::cout<<"operator == between bezier called."<<std::endl;
+    return  T_min_ == other.min()
+        && T_max_ == other.max()
+        && dim_ == other.dim()
+        && degree_ == other.degree()
+        && size_ == other.size_
+        && mult_T_ == other.mult_T_
+        && bernstein_ == other.bernstein_;
+  }
+
+  virtual bool operator!=(const bezier_curve_t& other) const {
+    return !(*this == other);
+  }
+
+  virtual bool operator==(const curve_abc_t& other) const {
+    return curve_abc_t::isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_abc_t& other) const {
+    return !curve_abc_t::isApprox(other);
+  }
+
+
   ///  \brief Compute the derived curve at order N.
   ///  Computes the derivative order N, \f$\frac{d^Nx(t)}{dt^N}\f$ of bezier curve of parametric equation x(t).
   ///  \param order : order of derivative.

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -177,13 +177,6 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
       return curve_abc_t::isApprox(other,prec,order);
   }
 
-  virtual bool operator==(const curve_abc_t& other) const {
-      return isApprox(other);
-  }
-
-  virtual bool operator!=(const curve_abc_t& other) const {
-    return !(*this == other);
-  }
 
 
   ///  \brief Compute the derived curve at order N.

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -140,15 +140,29 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
     }
   }
 
-  virtual bool operator==(const bezier_curve_t& other) const {
-    //std::cout<<"operator == between bezier called."<<std::endl;
-    return  T_min_ == other.min()
+  virtual bool isApprox(const bezier_curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    //std::cout<<"is approx in bezier called."<<std::endl;
+    (void)order;
+    bool equal = T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()
         && degree_ == other.degree()
         && size_ == other.size_
         && mult_T_ == other.mult_T_
         && bernstein_ == other.bernstein_;
+    if(!equal)
+      return false;
+    for (size_t i = 0 ;i < size_;++i)
+    {
+      if(!control_points_.at(i).isApprox(other.control_points_.at(i),prec))
+        return false;
+    }
+    return true;
+  }
+
+
+  virtual bool operator==(const bezier_curve_t& other) const {
+    return isApprox(other);
   }
 
   virtual bool operator!=(const bezier_curve_t& other) const {
@@ -158,7 +172,7 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
     const bezier_curve_t* other_cast = dynamic_cast<const bezier_curve_t*>(&other);
     if(other_cast)
-      return (*this == *other_cast); // no isApprox between two bezier, only exact equality
+      return isApprox(*other_cast);
     else
       return curve_abc_t::isApprox(other,prec,order);
   }

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -155,12 +155,20 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
     return !(*this == other);
   }
 
+  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    const bezier_curve_t* other_cast = dynamic_cast<const bezier_curve_t*>(&other);
+    if(other_cast)
+      return (*this == *other_cast); // no isApprox between two bezier, only exact equality
+    else
+      return curve_abc_t::isApprox(other,prec,order);
+  }
+
   virtual bool operator==(const curve_abc_t& other) const {
-    return curve_abc_t::isApprox(other);
+      return isApprox(other);
   }
 
   virtual bool operator!=(const curve_abc_t& other) const {
-    return !curve_abc_t::isApprox(other);
+    return !(*this == other);
   }
 
 

--- a/include/curves/bezier_curve.h
+++ b/include/curves/bezier_curve.h
@@ -140,9 +140,15 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
     }
   }
 
-  virtual bool isApprox(const bezier_curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    //std::cout<<"is approx in bezier called."<<std::endl;
-    (void)order;
+  /**
+   * @brief isApprox check if other and *this are approximately equals.
+   * Only two curves of the same class can be approximately equals, for comparison between different type of curves see isEquivalent
+   * @param other the other curve to check
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  bool isApprox(const bezier_curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    std::cout<<"is approx in bezier called."<<std::endl;
     bool equal = T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()
@@ -160,6 +166,14 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
     return true;
   }
 
+  virtual bool isApprox(const curve_abc_t* other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    const bezier_curve_t* other_cast = dynamic_cast<const bezier_curve_t*>(other);
+    if(other_cast)
+      return isApprox(*other_cast,prec);
+    else
+      return false;
+  }
+
 
   virtual bool operator==(const bezier_curve_t& other) const {
     return isApprox(other);
@@ -168,15 +182,6 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
   virtual bool operator!=(const bezier_curve_t& other) const {
     return !(*this == other);
   }
-
-  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    const bezier_curve_t* other_cast = dynamic_cast<const bezier_curve_t*>(&other);
-    if(other_cast)
-      return isApprox(*other_cast);
-    else
-      return curve_abc_t::isApprox(other,prec,order);
-  }
-
 
 
   ///  \brief Compute the derived curve at order N.

--- a/include/curves/cubic_hermite_spline.h
+++ b/include/curves/cubic_hermite_spline.h
@@ -149,13 +149,6 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
       return curve_abc_t::isApprox(other,prec,order);
   }
 
-  virtual bool operator==(const curve_abc_t& other) const {
-    return isApprox(other);
-  }
-
-  virtual bool operator!=(const curve_abc_t& other) const {
-    return !(*this == other);
-  }
 
 
   ///  \brief Evaluate the derivative of order N of spline at time t.

--- a/include/curves/cubic_hermite_spline.h
+++ b/include/curves/cubic_hermite_spline.h
@@ -103,6 +103,53 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
     }
   }
 
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const cubic_hermite_spline_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    //std::cout<<"is approx in hermite called."<<std::endl;
+    (void)order; // silent warning, order is not used in this class.
+    bool equal =  T_min_ == other.min()
+        && T_max_ == other.max()
+        && dim_ == other.dim()
+        && degree_ == other.degree()
+        && size_ == other.size()
+        && time_control_points_ == other.time_control_points_
+        && duration_splines_ == other.duration_splines_;
+    if(!equal)
+      return false;
+    for (std::size_t i = 0 ; i < size_ ;++i)
+    {
+      if((!control_points_[i].first.isApprox(other.control_points_[i].first,prec)) ||
+         (!control_points_[i].second.isApprox(other.control_points_[i].second,prec)) )
+        return false;
+    }
+    return true;
+  }
+
+  virtual bool operator==(const cubic_hermite_spline_t& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const cubic_hermite_spline_t& other) const {
+    return !(*this == other);
+  }
+
+  virtual bool operator==(const curve_abc_t& other) const {
+    return curve_abc_t::isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_abc_t& other) const {
+    return !curve_abc_t::isApprox(other);
+  }
+
+
   ///  \brief Evaluate the derivative of order N of spline at time t.
   ///  \param t : time when to evaluate the spline.
   ///  \param order : order of derivative.

--- a/include/curves/cubic_hermite_spline.h
+++ b/include/curves/cubic_hermite_spline.h
@@ -141,12 +141,20 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
     return !(*this == other);
   }
 
+  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    const cubic_hermite_spline_t* other_cast = dynamic_cast<const cubic_hermite_spline_t*>(&other);
+    if(other_cast)
+      return isApprox(*other_cast);
+    else
+      return curve_abc_t::isApprox(other,prec,order);
+  }
+
   virtual bool operator==(const curve_abc_t& other) const {
-    return curve_abc_t::isApprox(other);
+    return isApprox(other);
   }
 
   virtual bool operator!=(const curve_abc_t& other) const {
-    return !curve_abc_t::isApprox(other);
+    return !(*this == other);
   }
 
 

--- a/include/curves/cubic_hermite_spline.h
+++ b/include/curves/cubic_hermite_spline.h
@@ -104,17 +104,14 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
   }
 
   /**
-   * @brief isApprox check if other and *this are equals, given a precision treshold.
-   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
-   * all the members.
+   * @brief isApprox check if other and *this are approximately equals.
+   * Only two curves of the same class can be approximately equals, for comparison between different type of curves see isEquivalent
    * @param other the other curve to check
-   * @param order the order up to which the derivatives of the curves are checked for equality
    * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
    * @return true is the two curves are approximately equals
    */
-  virtual bool isApprox(const cubic_hermite_spline_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    //std::cout<<"is approx in hermite called."<<std::endl;
-    (void)order; // silent warning, order is not used in this class.
+  bool isApprox(const cubic_hermite_spline_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    std::cout<<"is approx in hermite called."<<std::endl;
     bool equal =  T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()
@@ -133,20 +130,20 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
     return true;
   }
 
+  virtual bool isApprox(const curve_abc_t* other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    const cubic_hermite_spline_t* other_cast = dynamic_cast<const cubic_hermite_spline_t*>(other);
+    if(other_cast)
+      return isApprox(*other_cast,prec);
+    else
+      return false;
+  }
+
   virtual bool operator==(const cubic_hermite_spline_t& other) const {
     return isApprox(other);
   }
 
   virtual bool operator!=(const cubic_hermite_spline_t& other) const {
     return !(*this == other);
-  }
-
-  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    const cubic_hermite_spline_t* other_cast = dynamic_cast<const cubic_hermite_spline_t*>(&other);
-    if(other_cast)
-      return isApprox(*other_cast);
-    else
-      return curve_abc_t::isApprox(other,prec,order);
   }
 
 

--- a/include/curves/cubic_hermite_spline.h
+++ b/include/curves/cubic_hermite_spline.h
@@ -111,7 +111,6 @@ struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
    * @return true is the two curves are approximately equals
    */
   bool isApprox(const cubic_hermite_spline_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
-    std::cout<<"is approx in hermite called."<<std::endl;
     bool equal =  T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()

--- a/include/curves/curve_abc.h
+++ b/include/curves/curve_abc.h
@@ -59,7 +59,42 @@ struct curve_abc : std::unary_function<Time, Point>, public serialization::Seria
   /// \return \f$\frac{d^Nx(t)}{dt^N}\f$, point corresponding on derivative curve of order N at time t.
   virtual point_derivate_t derivate(const time_t t, const std::size_t order) const = 0;
 
-
+  /**
+   * @brief isEquivalent check if other and *this are approximately equal by values, given a precision treshold.
+   * This test is done by discretizing both curves and evaluating them and their derivatives.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  bool isEquivalent(const curve_t* other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    std::cout<<"is equivalent in curve_abc called"<<std::endl;
+    bool equal = (min() == other->min())
+               && (max() == other->max())
+               && (dim() == other->dim());
+    if(!equal){
+      return false;
+    }
+    // check the value along the two curves
+    Numeric t = min();
+    while(t<= max()){
+      if(!(*this)(t).isApprox(other->operator()(t),prec)){
+        return false;
+      }
+      t += 0.01; // FIXME : define this step somewhere ??
+    }
+    //  check if the derivatives are equals
+    for(size_t n = 1 ; n <= order ; ++n){
+      t = min();
+      while(t<= max()){
+        if(!derivate(t,n).isApprox(other->derivate(t,n),prec)){
+          return false;
+        }
+        t += 0.01; // FIXME : define this step somewhere ??
+      }
+    }
+    return true;
+  }
 
   /**
    * @brief isApprox check if other and *this are approximately equals given a precision treshold

--- a/include/curves/curve_abc.h
+++ b/include/curves/curve_abc.h
@@ -59,6 +59,50 @@ struct curve_abc : std::unary_function<Time, Point>, public serialization::Seria
   /// \return \f$\frac{d^Nx(t)}{dt^N}\f$, point corresponding on derivative curve of order N at time t.
   virtual point_derivate_t derivate(const time_t t, const std::size_t order) const = 0;
 
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    bool equal = (min() == other.min())
+               && (max() == other.max())
+               && (dim() == other.dim());
+    if(!equal){
+      return false;
+    }
+    // check the value along the two curves
+    Numeric t = min();
+    while(t<= max()){
+      if(!(*this)(t).isApprox(other(t),prec)){
+        return false;
+      }
+      t += 0.01; // FIXME : define this step somewhere ??
+    }
+    //  check if the derivatives are equals
+    for(size_t n = 1 ; n <= order ; ++n){
+      t = min();
+      while(t<= max()){
+        if(!derivate(t,n).isApprox(other.derivate(t,n),prec)){
+          return false;
+        }
+        t += 0.01; // FIXME : define this step somewhere ??
+      }
+    }
+    return true;
+  }
+
+  virtual bool operator==(const curve_t& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_t& other) const {
+    return !(*this == other);
+  }
 
   /*Operations*/
 

--- a/include/curves/curve_abc.h
+++ b/include/curves/curve_abc.h
@@ -96,14 +96,6 @@ struct curve_abc : std::unary_function<Time, Point>, public serialization::Seria
     return true;
   }
 
-  virtual bool operator==(const curve_t& other) const {
-    return isApprox(other);
-  }
-
-  virtual bool operator!=(const curve_t& other) const {
-    return !(*this == other);
-  }
-
   /*Operations*/
 
   /*Helpers*/

--- a/include/curves/curve_abc.h
+++ b/include/curves/curve_abc.h
@@ -59,42 +59,17 @@ struct curve_abc : std::unary_function<Time, Point>, public serialization::Seria
   /// \return \f$\frac{d^Nx(t)}{dt^N}\f$, point corresponding on derivative curve of order N at time t.
   virtual point_derivate_t derivate(const time_t t, const std::size_t order) const = 0;
 
+
+
   /**
-   * @brief isApprox check if other and *this are equals, given a precision treshold.
-   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
-   * all the members.
+   * @brief isApprox check if other and *this are approximately equals given a precision treshold
+   * Only two curves of the same class can be approximately equals,
+   * for comparison between different type of curves see isEquivalent.
    * @param other the other curve to check
-   * @param order the order up to which the derivatives of the curves are checked for equality
    * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
    * @return true is the two curves are approximately equals
    */
-  virtual bool isApprox(const curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    bool equal = (min() == other.min())
-               && (max() == other.max())
-               && (dim() == other.dim());
-    if(!equal){
-      return false;
-    }
-    // check the value along the two curves
-    Numeric t = min();
-    while(t<= max()){
-      if(!(*this)(t).isApprox(other(t),prec)){
-        return false;
-      }
-      t += 0.01; // FIXME : define this step somewhere ??
-    }
-    //  check if the derivatives are equals
-    for(size_t n = 1 ; n <= order ; ++n){
-      t = min();
-      while(t<= max()){
-        if(!derivate(t,n).isApprox(other.derivate(t,n),prec)){
-          return false;
-        }
-        t += 0.01; // FIXME : define this step somewhere ??
-      }
-    }
-    return true;
-  }
+  virtual bool isApprox(const curve_t* other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const = 0;
 
   /*Operations*/
 

--- a/include/curves/curve_abc.h
+++ b/include/curves/curve_abc.h
@@ -68,7 +68,6 @@ struct curve_abc : std::unary_function<Time, Point>, public serialization::Seria
    * @return true is the two curves are approximately equals
    */
   bool isEquivalent(const curve_t* other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    std::cout<<"is equivalent in curve_abc called"<<std::endl;
     bool equal = (min() == other->min())
                && (max() == other->max())
                && (dim() == other->dim());

--- a/include/curves/exact_cubic.h
+++ b/include/curves/exact_cubic.h
@@ -109,6 +109,17 @@ struct exact_cubic : public piecewise_curve<Time, Numeric, Safe, Point> {
   /// \brief Destructor.
   virtual ~exact_cubic() {}
 
+  /**
+   * @brief isApprox check if other and *this are approximately equals.
+   * Only two curves of the same class can be approximately equals, for comparison between different type of curves see isEquivalent
+   * @param other the other curve to check
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  bool isApprox(const exact_cubic_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    return piecewise_curve_t::isApprox(other,prec);
+  }
+
   std::size_t getNumberSplines() { return this->getNumberCurves(); }
 
   spline_t getSplineAt(std::size_t index) {

--- a/include/curves/fwd.h
+++ b/include/curves/fwd.h
@@ -62,7 +62,7 @@ typedef Eigen::Matrix<double, 3, 3> matrix3_t;
 typedef Eigen::Matrix<double, 4, 4> matrix4_t;
 typedef Eigen::Quaternion<double> quaternion_t;
 typedef Eigen::Transform<double, 3, Eigen::Affine> transform_t;
-typedef std::vector<pointX_t, Eigen::aligned_allocator<point3_t> > t_point3_t;
+typedef std::vector<point3_t, Eigen::aligned_allocator<point3_t> > t_point3_t;
 typedef std::vector<pointX_t, Eigen::aligned_allocator<pointX_t> > t_pointX_t;
 
 // abstract curves types:

--- a/include/curves/helpers/effector_spline_rotation.h
+++ b/include/curves/helpers/effector_spline_rotation.h
@@ -72,6 +72,33 @@ class rotation_spline : public curve_abc_quat_t {
     return quat_from_.slerp(time_reparam_(u)[0], quat_to_).coeffs();
   }
 
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const rotation_spline& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    return min_ == other.min_
+        && max_ == other.max_
+        && dim_ == other.dim_
+        && quat_from_.isApprox(other.quat_from_,prec)
+        && quat_to_.isApprox(other.quat_to_,prec)
+        && time_reparam_.isApprox(other.time_reparam_,prec,order);
+  }
+
+  virtual bool operator==(const rotation_spline& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const rotation_spline& other) const {
+    return !(*this == other);
+  }
+
+
   virtual quat_t derivate(time_t /*t*/, std::size_t /*order*/) const {
     throw std::runtime_error("TODO quaternion spline does not implement derivate");
   }

--- a/include/curves/helpers/effector_spline_rotation.h
+++ b/include/curves/helpers/effector_spline_rotation.h
@@ -73,21 +73,27 @@ class rotation_spline : public curve_abc_quat_t {
   }
 
   /**
-   * @brief isApprox check if other and *this are equals, given a precision treshold.
-   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
-   * all the members.
+   * @brief isApprox check if other and *this are approximately equals.
+   * Only two curves of the same class can be approximately equals, for comparison between different type of curves see isEquivalent
    * @param other the other curve to check
-   * @param order the order up to which the derivatives of the curves are checked for equality
    * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
    * @return true is the two curves are approximately equals
    */
-  virtual bool isApprox(const rotation_spline& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+  bool isApprox(const rotation_spline& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
     return min_ == other.min_
         && max_ == other.max_
         && dim_ == other.dim_
         && quat_from_.isApprox(other.quat_from_,prec)
         && quat_to_.isApprox(other.quat_to_,prec)
-        && time_reparam_.isApprox(other.time_reparam_,prec,order);
+        && time_reparam_.isApprox(other.time_reparam_,prec);
+  }
+
+  virtual bool isApprox(const curve_abc_quat_t* other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    const rotation_spline* other_cast = dynamic_cast<const rotation_spline*>(other);
+    if(other_cast)
+      return isApprox(*other_cast,prec);
+    else
+      return false;
   }
 
   virtual bool operator==(const rotation_spline& other) const {

--- a/include/curves/linear_variable.h
+++ b/include/curves/linear_variable.h
@@ -81,7 +81,7 @@ struct linear_variable : public serialization::Serializable {
 
   Numeric norm() const { return isZero() ? 0 : (B_.norm() + c_.norm()); }
 
-  bool isApprox(const linear_variable_t& other,const double prec = Eigen::NumTraits<Numeric>::dummy_precision()){
+  bool isApprox(const linear_variable_t& other,const double prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
     return (*this - other).norm() < prec;
   }
 

--- a/include/curves/piecewise_curve.h
+++ b/include/curves/piecewise_curve.h
@@ -88,7 +88,6 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point,Point_deriv
    * @return true is the two curves are approximately equals
    */
   bool isApprox(const piecewise_curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
-    std::cout<<"is approx in piecewise called."<<std::endl;
     if(num_curves() != other.num_curves())
       return false;
     for (size_t i = 0 ; i < num_curves() ; ++i) {

--- a/include/curves/piecewise_curve.h
+++ b/include/curves/piecewise_curve.h
@@ -81,25 +81,30 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point,Point_deriv
   }
 
   /**
-   * @brief isApprox check if other and *this are equals, given a precision treshold.
-   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
-   * all the members.
+   * @brief isApprox check if other and *this are approximately equals.
+   * Only two curves of the same class can be approximately equals, for comparison between different type of curves see isEquivalent
    * @param other the other curve to check
-   * @param order the order up to which the derivatives of the curves are checked for equality
    * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
    * @return true is the two curves are approximately equals
    */
-  virtual bool isApprox(const piecewise_curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+  bool isApprox(const piecewise_curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
     std::cout<<"is approx in piecewise called."<<std::endl;
     if(num_curves() != other.num_curves())
       return false;
     for (size_t i = 0 ; i < num_curves() ; ++i) {
-      if(! curve_at_index(i)->isApprox(*other.curve_at_index(i),prec,order))
+      if(! curve_at_index(i)->isApprox(other.curve_at_index(i).get(),prec))
         return false;
     }
     return true;
   }
 
+  virtual bool isApprox(const curve_t* other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    const piecewise_curve_t* other_cast = dynamic_cast<const piecewise_curve_t*>(other);
+    if(other_cast)
+      return isApprox(*other_cast,prec);
+    else
+      return false;
+  }
 
   virtual bool operator==(const piecewise_curve_t& other) const {
     return isApprox(other);

--- a/include/curves/piecewise_curve.h
+++ b/include/curves/piecewise_curve.h
@@ -80,6 +80,35 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point,Point_deriv
     return (*curves_.at(find_interval(t)))(t);
   }
 
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const piecewise_curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    std::cout<<"is approx in piecewise called."<<std::endl;
+    if(num_curves() != other.num_curves())
+      return false;
+    for (size_t i = 0 ; i < num_curves() ; ++i) {
+      if(! curve_at_index(i)->isApprox(*other.curve_at_index(i),prec,order))
+        return false;
+    }
+    return true;
+  }
+
+
+  virtual bool operator==(const piecewise_curve_t& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const piecewise_curve_t& other) const {
+    return !(*this == other);
+  }
+
   ///  \brief Evaluate the derivative of order N of curve at time t.
   ///  \param t : time when to evaluate the spline.
   ///  \param order : order of derivative.

--- a/include/curves/polynomial.h
+++ b/include/curves/polynomial.h
@@ -255,17 +255,14 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
   }
 
   /**
-   * @brief isApprox check if other and *this are equals, given a precision treshold.
-   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
-   * all the members.
+   * @brief isApprox check if other and *this are approximately equals.
+   * Only two curves of the same class can be approximately equals, for comparison between different type of curves see isEquivalent
    * @param other the other curve to check
-   * @param order the order up to which the derivatives of the curves are checked for equality
    * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
    * @return true is the two curves are approximately equals
    */
-  virtual bool isApprox(const polynomial_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    //std::cout<<"is approx in polynomial called."<<std::endl;
-    (void)order; // silent warning, order is not used in this class.
+  bool isApprox(const polynomial_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    std::cout<<"is approx in polynomial called."<<std::endl;
     return T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()
@@ -273,20 +270,21 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
         && coefficients_.isApprox(other.coefficients_,prec);
   }
 
+  virtual bool isApprox(const curve_abc_t* other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    const polynomial_t* other_cast = dynamic_cast<const polynomial_t*>(other);
+    if(other_cast)
+      return isApprox(*other_cast,prec);
+    else
+      return false;
+  }
+
+
   virtual bool operator==(const polynomial_t& other) const {
     return isApprox(other);
   }
 
   virtual bool operator!=(const polynomial_t& other) const {
     return !(*this == other);
-  }
-
-  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    const polynomial_t* other_cast = dynamic_cast<const polynomial_t*>(&other);
-    if(other_cast)
-      return isApprox(*other_cast);
-    else
-      return curve_abc_t::isApprox(other,prec,order);
   }
 
 

--- a/include/curves/polynomial.h
+++ b/include/curves/polynomial.h
@@ -254,6 +254,42 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
     return h;
   }
 
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const polynomial_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    //std::cout<<"is approx in polynomial called."<<std::endl;
+    (void)order; // silent warning, order is not used in this class.
+    return T_min_ == other.min()
+        && T_max_ == other.max()
+        && dim_ == other.dim()
+        && degree_ == other.degree()
+        && coefficients_.isApprox(other.coefficients_,prec);
+  }
+
+  virtual bool operator==(const polynomial_t& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const polynomial_t& other) const {
+    return !(*this == other);
+  }
+
+  virtual bool operator==(const curve_abc_t& other) const {
+    return curve_abc_t::isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_abc_t& other) const {
+    return !curve_abc_t::isApprox(other);
+  }
+
+
   ///  \brief Evaluation of the derivative of order N of spline at time t.
   ///  \param t : the time when to evaluate the spline.
   ///  \param order : order of derivative.

--- a/include/curves/polynomial.h
+++ b/include/curves/polynomial.h
@@ -281,12 +281,20 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
     return !(*this == other);
   }
 
+  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    const polynomial_t* other_cast = dynamic_cast<const polynomial_t*>(&other);
+    if(other_cast)
+      return isApprox(*other_cast);
+    else
+      return curve_abc_t::isApprox(other,prec,order);
+  }
+
   virtual bool operator==(const curve_abc_t& other) const {
-    return curve_abc_t::isApprox(other);
+    return isApprox(other);
   }
 
   virtual bool operator!=(const curve_abc_t& other) const {
-    return !curve_abc_t::isApprox(other);
+    return !(*this == other);
   }
 
 

--- a/include/curves/polynomial.h
+++ b/include/curves/polynomial.h
@@ -262,7 +262,6 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
    * @return true is the two curves are approximately equals
    */
   bool isApprox(const polynomial_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
-    std::cout<<"is approx in polynomial called."<<std::endl;
     return T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()

--- a/include/curves/polynomial.h
+++ b/include/curves/polynomial.h
@@ -289,13 +289,6 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
       return curve_abc_t::isApprox(other,prec,order);
   }
 
-  virtual bool operator==(const curve_abc_t& other) const {
-    return isApprox(other);
-  }
-
-  virtual bool operator!=(const curve_abc_t& other) const {
-    return !(*this == other);
-  }
 
 
   ///  \brief Evaluation of the derivative of order N of spline at time t.

--- a/include/curves/se3_curve.h
+++ b/include/curves/se3_curve.h
@@ -183,14 +183,6 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
     else
       return curve_abc_t::isApprox(other,prec,order);
   }
-  virtual bool operator==(const curve_abc_t& other) const {
-    return isApprox(other);
-  }
-
-  virtual bool operator!=(const curve_abc_t& other) const {
-    return !(*this == other);
-  }
-
 
   ///  \brief Evaluation of the derivative of order N of spline at time t.
   ///  \param t : the time when to evaluate the spline.

--- a/include/curves/se3_curve.h
+++ b/include/curves/se3_curve.h
@@ -176,12 +176,19 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
     return !(*this == other);
   }
 
+  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    const SE3Curve_t* other_cast = dynamic_cast<const SE3Curve_t*>(&other);
+    if(other_cast)
+      return isApprox(*other_cast);
+    else
+      return curve_abc_t::isApprox(other,prec,order);
+  }
   virtual bool operator==(const curve_abc_t& other) const {
-    return curve_abc_t::isApprox(other);
+    return isApprox(other);
   }
 
   virtual bool operator!=(const curve_abc_t& other) const {
-    return !curve_abc_t::isApprox(other);
+    return !(*this == other);
   }
 
 

--- a/include/curves/se3_curve.h
+++ b/include/curves/se3_curve.h
@@ -151,22 +151,28 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
   }
 
   /**
-   * @brief isApprox check if other and *this are equals, given a precision treshold.
-   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
-   * all the members.
+   * @brief isApprox check if other and *this are approximately equals.
+   * Only two curves of the same class can be approximately equals, for comparison between different type of curves see isEquivalent
    * @param other the other curve to check
-   * @param order the order up to which the derivatives of the curves are checked for equality
    * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
    * @return true is the two curves are approximately equals
    */
-  virtual bool isApprox(const SE3Curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    //std::cout<<"is approx in SE3 called."<<std::endl;
-    (void)order; // silent warning, order is not used in this class.
+  bool isApprox(const SE3Curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    std::cout<<"is approx in SE3 called."<<std::endl;
     return T_min_ == other.min()
         && T_max_ == other.max()
-        && (translation_curve_ == other.translation_curve_ || translation_curve_->isApprox(*other.translation_curve_,prec))
-        && (rotation_curve_ == other.rotation_curve_ || rotation_curve_->isApprox(*other.rotation_curve_,prec));
+        && (translation_curve_ == other.translation_curve_ || translation_curve_->isApprox(other.translation_curve_.get(),prec))
+        && (rotation_curve_ == other.rotation_curve_ || rotation_curve_->isApprox(other.rotation_curve_.get(),prec));
   }
+
+  virtual bool isApprox(const curve_abc_t* other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    const SE3Curve_t* other_cast = dynamic_cast<const SE3Curve_t*>(other);
+    if(other_cast)
+      return isApprox(*other_cast,prec);
+    else
+      return false;
+  }
+
 
   virtual bool operator==(const SE3Curve_t& other) const {
     return isApprox(other);
@@ -176,13 +182,6 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
     return !(*this == other);
   }
 
-  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    const SE3Curve_t* other_cast = dynamic_cast<const SE3Curve_t*>(&other);
-    if(other_cast)
-      return isApprox(*other_cast);
-    else
-      return curve_abc_t::isApprox(other,prec,order);
-  }
 
   ///  \brief Evaluation of the derivative of order N of spline at time t.
   ///  \param t : the time when to evaluate the spline.

--- a/include/curves/se3_curve.h
+++ b/include/curves/se3_curve.h
@@ -158,7 +158,6 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
    * @return true is the two curves are approximately equals
    */
   bool isApprox(const SE3Curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
-    std::cout<<"is approx in SE3 called."<<std::endl;
     return T_min_ == other.min()
         && T_max_ == other.max()
         && (translation_curve_ == other.translation_curve_ || translation_curve_->isApprox(other.translation_curve_.get(),prec))

--- a/include/curves/se3_curve.h
+++ b/include/curves/se3_curve.h
@@ -150,6 +150,41 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
     return res;
   }
 
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const SE3Curve_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    //std::cout<<"is approx in SE3 called."<<std::endl;
+    (void)order; // silent warning, order is not used in this class.
+    return T_min_ == other.min()
+        && T_max_ == other.max()
+        && (translation_curve_ == other.translation_curve_ || translation_curve_->isApprox(*other.translation_curve_,prec))
+        && (rotation_curve_ == other.rotation_curve_ || rotation_curve_->isApprox(*other.rotation_curve_,prec));
+  }
+
+  virtual bool operator==(const SE3Curve_t& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const SE3Curve_t& other) const {
+    return !(*this == other);
+  }
+
+  virtual bool operator==(const curve_abc_t& other) const {
+    return curve_abc_t::isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_abc_t& other) const {
+    return !curve_abc_t::isApprox(other);
+  }
+
+
   ///  \brief Evaluation of the derivative of order N of spline at time t.
   ///  \param t : the time when to evaluate the spline.
   ///  \param order : order of derivative.

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -142,14 +142,6 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
       return curve_abc_t::isApprox(other,prec,order);
   }
 
-  virtual bool operator==(const curve_abc_t& other) const {
-    return isApprox(other);
-  }
-
-  virtual bool operator!=(const curve_abc_t& other) const {
-    return !(*this == other);
-  }
-
 
   ///  \brief Evaluation of the derivative of order N of spline at time t.
   ///  \param t : the time when to evaluate the spline.

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -108,17 +108,14 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
   virtual matrix3_t operator()(const time_t t) const { return computeAsQuaternion(t).toRotationMatrix(); }
 
   /**
-   * @brief isApprox check if other and *this are equals, given a precision treshold.
-   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
-   * all the members.
+   * @brief isApprox check if other and *this are approximately equals.
+   * Only two curves of the same class can be approximately equals, for comparison between different type of curves see isEquivalent
    * @param other the other curve to check
-   * @param order the order up to which the derivatives of the curves are checked for equality
    * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
    * @return true is the two curves are approximately equals
    */
-  virtual bool isApprox(const SO3Linear_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    //std::cout<<"is approx in SO3 called."<<std::endl;
-    (void)order; // silent warning, order is not used in this class.
+  bool isApprox(const SO3Linear_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    std::cout<<"is approx in SO3 called."<<std::endl;
     return  T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()
@@ -126,20 +123,21 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
         && end_rot_.toRotationMatrix().isApprox(other.end_rot_.toRotationMatrix(),prec);
   }
 
+  virtual bool isApprox(const curve_abc_t* other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
+    const SO3Linear_t* other_cast = dynamic_cast<const SO3Linear_t*>(other);
+    if(other_cast)
+      return isApprox(*other_cast,prec);
+    else
+      return false;
+  }
+
+
   virtual bool operator==(const SO3Linear_t& other) const {
     return isApprox(other);
   }
 
   virtual bool operator!=(const SO3Linear_t& other) const {
     return !(*this == other);
-  }
-
-  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
-    const SO3Linear_t* other_cast = dynamic_cast<const SO3Linear_t*>(&other);
-    if(other_cast)
-      return isApprox(*other_cast);
-    else
-      return curve_abc_t::isApprox(other,prec,order);
   }
 
 

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -107,6 +107,42 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
   ///  \return \f$x(t)\f$ point corresponding on spline at time t.
   virtual matrix3_t operator()(const time_t t) const { return computeAsQuaternion(t).toRotationMatrix(); }
 
+  /**
+   * @brief isApprox check if other and *this are equals, given a precision treshold.
+   * This test is done by discretizing, it should be re-implemented in the child class to check exactly
+   * all the members.
+   * @param other the other curve to check
+   * @param order the order up to which the derivatives of the curves are checked for equality
+   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
+   * @return true is the two curves are approximately equals
+   */
+  virtual bool isApprox(const SO3Linear_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    //std::cout<<"is approx in SO3 called."<<std::endl;
+    (void)order; // silent warning, order is not used in this class.
+    return  T_min_ == other.min()
+        && T_max_ == other.max()
+        && dim_ == other.dim()
+        && init_rot_.isApprox(other.init_rot_,prec)
+        && end_rot_.isApprox(other.end_rot_,prec);
+  }
+
+  virtual bool operator==(const SO3Linear_t& other) const {
+    return isApprox(other);
+  }
+
+  virtual bool operator!=(const SO3Linear_t& other) const {
+    return !(*this == other);
+  }
+
+  virtual bool operator==(const curve_abc_t& other) const {
+    return curve_abc_t::isApprox(other);
+  }
+
+  virtual bool operator!=(const curve_abc_t& other) const {
+    return !curve_abc_t::isApprox(other);
+  }
+
+
   ///  \brief Evaluation of the derivative of order N of spline at time t.
   ///  \param t : the time when to evaluate the spline.
   ///  \param order : order of derivative.

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -115,7 +115,6 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
    * @return true is the two curves are approximately equals
    */
   bool isApprox(const SO3Linear_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const{
-    std::cout<<"is approx in SO3 called."<<std::endl;
     return  T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -122,8 +122,8 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
     return  T_min_ == other.min()
         && T_max_ == other.max()
         && dim_ == other.dim()
-        && init_rot_.isApprox(other.init_rot_,prec)
-        && end_rot_.isApprox(other.end_rot_,prec);
+        && init_rot_.toRotationMatrix().isApprox(other.init_rot_.toRotationMatrix(),prec)
+        && end_rot_.toRotationMatrix().isApprox(other.end_rot_.toRotationMatrix(),prec);
   }
 
   virtual bool operator==(const SO3Linear_t& other) const {

--- a/include/curves/so3_linear.h
+++ b/include/curves/so3_linear.h
@@ -134,12 +134,20 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, Eigen::Matrix<Numeric, 
     return !(*this == other);
   }
 
+  virtual bool isApprox(const curve_abc_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision(),const size_t order = 5) const{
+    const SO3Linear_t* other_cast = dynamic_cast<const SO3Linear_t*>(&other);
+    if(other_cast)
+      return isApprox(*other_cast);
+    else
+      return curve_abc_t::isApprox(other,prec,order);
+  }
+
   virtual bool operator==(const curve_abc_t& other) const {
-    return curve_abc_t::isApprox(other);
+    return isApprox(other);
   }
 
   virtual bool operator!=(const curve_abc_t& other) const {
-    return !curve_abc_t::isApprox(other);
+    return !(*this == other);
   }
 
 

--- a/python/curves_python.cpp
+++ b/python/curves_python.cpp
@@ -22,6 +22,8 @@ struct CurveWrapper : curve_abc_t, wrapper<curve_abc_t> {
   real min() { return this->get_override("min")(); }
   real max() { return this->get_override("max")(); }
 };
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(curve_abc_t_isEquivalent_overloads, curve_abc_t::isEquivalent, 1, 3)
+
 struct Curve3Wrapper : curve_3_t, wrapper<curve_3_t> {
   point_t operator()(const real) { return this->get_override("operator()")(); }
   point_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
@@ -30,6 +32,8 @@ struct Curve3Wrapper : curve_3_t, wrapper<curve_3_t> {
   real min() { return this->get_override("min")(); }
   real max() { return this->get_override("max")(); }
 };
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(curve_3_t_isEquivalent_overloads, curve_3_t::isEquivalent, 1, 3)
+
 struct CurveRotationWrapper : curve_rotation_t, wrapper<curve_rotation_t> {
   point_t operator()(const real) { return this->get_override("operator()")(); }
   point_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
@@ -38,6 +42,8 @@ struct CurveRotationWrapper : curve_rotation_t, wrapper<curve_rotation_t> {
   real min() { return this->get_override("min")(); }
   real max() { return this->get_override("max")(); }
 };
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(curve_rotation_t_isEquivalent_overloads, curve_rotation_t::isEquivalent, 1, 3)
+
 struct CurveSE3Wrapper : curve_SE3_t, wrapper<curve_SE3_t> {
   point_t operator()(const real) { return this->get_override("operator()")(); }
   point_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
@@ -46,6 +52,8 @@ struct CurveSE3Wrapper : curve_SE3_t, wrapper<curve_SE3_t> {
   real min() { return this->get_override("min")(); }
   real max() { return this->get_override("max")(); }
 };
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(curve_SE3_t_isEquivalent_overloads, curve_SE3_t::isEquivalent, 1, 3)
+
 /* end base wrap of curve_abc */
 
 /* Template constructor bezier */
@@ -405,6 +413,11 @@ BOOST_PYTHON_MODULE(curves) {
            args("self", "t"))
       .def("derivate", pure_virtual(&curve_abc_t::derivate), "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
+      .def("isEquivalent",&curve_abc_t::isEquivalent,curve_abc_t_isEquivalent_overloads(
+             (bp::arg("other"),
+             bp::arg("prec") = Eigen::NumTraits<double>::dummy_precision(),
+             bp::arg("order") = 5),
+           "isEquivalent check if self and other are approximately equal by values, given a precision treshold."))
       .def("compute_derivate", pure_virtual(&curve_abc_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
       .def("min", pure_virtual(&curve_abc_t::min), "Get the LOWER bound on interval definition of the curve.")
       .def("max", pure_virtual(&curve_abc_t::max), "Get the HIGHER bound on interval definition of the curve.")
@@ -427,6 +440,11 @@ BOOST_PYTHON_MODULE(curves) {
            args("self", "t"))
       .def("derivate", pure_virtual(&curve_3_t::derivate), "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
+      .def("isEquivalent",&curve_3_t::isEquivalent,curve_3_t_isEquivalent_overloads(
+             (bp::arg("other"),
+             bp::arg("prec") = Eigen::NumTraits<double>::dummy_precision(),
+             bp::arg("order") = 5),
+           "isEquivalent check if self and other are approximately equal by values, given a precision treshold."))
       .def("compute_derivate", pure_virtual(&curve_3_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
       .def("min", pure_virtual(&curve_3_t::min), "Get the LOWER bound on interval definition of the curve.")
       .def("max", pure_virtual(&curve_3_t::max), "Get the HIGHER bound on interval definition of the curve.")
@@ -437,6 +455,11 @@ BOOST_PYTHON_MODULE(curves) {
            args("self", "t"))
       .def("derivate", pure_virtual(&curve_rotation_t::derivate),
            "Evaluate the derivative of order N of curve at time t.", args("self", "t", "N"))
+      .def("isEquivalent",&curve_rotation_t::isEquivalent,curve_rotation_t_isEquivalent_overloads(
+             (bp::arg("other"),
+             bp::arg("prec") = Eigen::NumTraits<double>::dummy_precision(),
+             bp::arg("order") = 5),
+           "isEquivalent check if self and other are approximately equal by values, given a precision treshold."))
       .def("compute_derivate", pure_virtual(&curve_rotation_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
       .def("min", pure_virtual(&curve_rotation_t::min), "Get the LOWER bound on interval definition of the curve.")
       .def("max", pure_virtual(&curve_rotation_t::max), "Get the HIGHER bound on interval definition of the curve.")
@@ -447,6 +470,11 @@ BOOST_PYTHON_MODULE(curves) {
            args("self", "t"))
       .def("derivate", pure_virtual(&curve_SE3_t::derivate),
            "Evaluate the derivative of order N of curve at time t. Return as a vector 6.", args("self", "t", "N"))
+      .def("isEquivalent",&curve_SE3_t::isEquivalent,curve_SE3_t_isEquivalent_overloads(
+             (bp::arg("other"),
+             bp::arg("prec") = Eigen::NumTraits<double>::dummy_precision(),
+             bp::arg("order") = 5),
+           "isEquivalent check if self and other are approximately equal by values, given a precision treshold."))
       .def("compute_derivate", pure_virtual(&curve_SE3_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
       .def("min", pure_virtual(&curve_SE3_t::min), "Get the LOWER bound on interval definition of the curve.")
       .def("max", pure_virtual(&curve_SE3_t::max), "Get the HIGHER bound on interval definition of the curve.")

--- a/python/curves_python.cpp
+++ b/python/curves_python.cpp
@@ -455,7 +455,7 @@ BOOST_PYTHON_MODULE(curves) {
       .def("__ne__", &curve_SE3_t::operator!=)
       .def("derivate", pure_virtual(&curve_SE3_t::derivate),
            "Evaluate the derivative of order N of curve at time t. Return as a vector 6.", args("self", "t", "N"))
-      .def("compute_derivate", pure_virtual(&curve_rotation_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
+      .def("compute_derivate", pure_virtual(&curve_SE3_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
       .def("min", pure_virtual(&curve_SE3_t::min), "Get the LOWER bound on interval definition of the curve.")
       .def("max", pure_virtual(&curve_SE3_t::max), "Get the HIGHER bound on interval definition of the curve.")
       .def("dim", pure_virtual(&curve_SE3_t::dim), "Get the dimension of the curve.")

--- a/python/curves_python.cpp
+++ b/python/curves_python.cpp
@@ -403,8 +403,6 @@ BOOST_PYTHON_MODULE(curves) {
   class_<CurveWrapper, boost::noncopyable>("curve", no_init)
       .def("__call__", pure_virtual(&curve_abc_t::operator()), "Evaluate the curve at the given time.",
            args("self", "t"))
-      .def("__eq__", &curve_abc_t::operator==)
-      .def("__ne__", &curve_abc_t::operator!=)
       .def("derivate", pure_virtual(&curve_abc_t::derivate), "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_abc_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
@@ -427,8 +425,6 @@ BOOST_PYTHON_MODULE(curves) {
   class_<Curve3Wrapper, boost::noncopyable, bases<curve_abc_t> >("curve3", no_init)
       .def("__call__", pure_virtual(&curve_3_t::operator()), "Evaluate the curve at the given time.",
            args("self", "t"))
-      .def("__eq__", &curve_3_t::operator==)
-      .def("__ne__", &curve_3_t::operator!=)
       .def("derivate", pure_virtual(&curve_3_t::derivate), "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_3_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
@@ -439,8 +435,6 @@ BOOST_PYTHON_MODULE(curves) {
   class_<CurveRotationWrapper, boost::noncopyable, bases<curve_abc_t> >("curve_rotation", no_init)
       .def("__call__", pure_virtual(&curve_rotation_t::operator()), "Evaluate the curve at the given time.",
            args("self", "t"))
-      .def("__eq__", &curve_rotation_t::operator==)
-      .def("__ne__", &curve_rotation_t::operator!=)
       .def("derivate", pure_virtual(&curve_rotation_t::derivate),
            "Evaluate the derivative of order N of curve at time t.", args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_rotation_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
@@ -451,8 +445,6 @@ BOOST_PYTHON_MODULE(curves) {
   class_<CurveSE3Wrapper, boost::noncopyable, bases<curve_abc_t> >("curve_SE3", no_init)
       .def("__call__", &se3Return, "Evaluate the curve at the given time. Return as an homogeneous matrix.",
            args("self", "t"))
-      .def("__eq__", &curve_SE3_t::operator==)
-      .def("__ne__", &curve_SE3_t::operator!=)
       .def("derivate", pure_virtual(&curve_SE3_t::derivate),
            "Evaluate the derivative of order N of curve at time t. Return as a vector 6.", args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_SE3_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
@@ -494,6 +486,8 @@ BOOST_PYTHON_MODULE(curves) {
       .def("loadFromBinary", &bezier3_t::loadFromBinary<bezier3_t>, bp::args("filename"),
            "Loads *this from a binary file.")
       //.def(SerializableVisitor<bezier_t>())
+      .def(bp::self == bp::self)
+      .def(bp::self != bp::self)
       ;
   /** END bezier3 curve**/
   /** BEGIN bezier curve**/
@@ -517,6 +511,8 @@ BOOST_PYTHON_MODULE(curves) {
            "Saves *this inside a binary file.")
       .def("loadFromBinary", &bezier_t::loadFromBinary<bezier_t>, bp::args("filename"),
            "Loads *this from a binary file.")
+      .def(bp::self == bp::self)
+      .def(bp::self != bp::self)
       //.def(SerializableVisitor<bezier_t>())
       ;
   /** END bezier curve**/
@@ -557,7 +553,10 @@ BOOST_PYTHON_MODULE(curves) {
       .def("waypoints", &wayPointsToLists, return_value_policy<manage_new_object>())
       .def("waypointAtIndex", &bezier_linear_variable_t::waypointAtIndex)
       .def_readonly("degree", &bezier_linear_variable_t::degree_)
-      .def_readonly("nbWaypoints", &bezier_linear_variable_t::size_);
+      .def_readonly("nbWaypoints", &bezier_linear_variable_t::size_)
+      .def(bp::self == bp::self)
+      .def(bp::self != bp::self)
+      ;
 
   class_<quadratic_variable_t>("cost", no_init)
       .add_property("A", &cost_t_quad)
@@ -609,7 +608,10 @@ BOOST_PYTHON_MODULE(curves) {
       .def("saveAsBinary", &polynomial_t::saveAsBinary<polynomial_t>, bp::args("filename"),
            "Saves *this inside a binary file.")
       .def("loadFromBinary", &polynomial_t::loadFromBinary<polynomial_t>, bp::args("filename"),
-           "Loads *this from a binary file.");
+           "Loads *this from a binary file.")
+      .def(bp::self == bp::self)
+      .def(bp::self != bp::self)
+      ;
 
   /** END polynomial function**/
   /** BEGIN piecewise curve function **/
@@ -673,7 +675,10 @@ BOOST_PYTHON_MODULE(curves) {
       .def("saveAsBinary", &piecewise_t::saveAsBinary<piecewise_t>,
            bp::args("filename"), "Saves *this inside a binary file.")
       .def("loadFromBinary", &piecewise_t::loadFromBinary<piecewise_t>,
-           bp::args("filename"), "Loads *this from a binary file.");
+           bp::args("filename"), "Loads *this from a binary file.")
+      .def(bp::self == bp::self)
+      .def(bp::self != bp::self)
+      ;
 
   class_<piecewise_SE3_t, bases<curve_SE3_t> >("piecewise_SE3", init<>())
       .def("__init__", make_constructor(&wrapPiecewiseSE3Constructor, default_call_policies(), arg("curve")),
@@ -704,6 +709,8 @@ BOOST_PYTHON_MODULE(curves) {
            "Saves *this inside a binary file.")
       .def("loadFromBinary", &piecewise_SE3_t::loadFromBinary<piecewise_SE3_t>, bp::args("filename"),
            "Loads *this from a binary file.")
+      .def(bp::self == bp::self)
+      .def(bp::self != bp::self)
         #ifdef CURVES_WITH_PINOCCHIO_SUPPORT
           .def("append", &addFinalSE3,
            "Append a new linear SE3 curve at the end of the piecewise curve, defined between self.max() "
@@ -730,7 +737,10 @@ BOOST_PYTHON_MODULE(curves) {
       .def("saveAsBinary", &exact_cubic_t::saveAsBinary<exact_cubic_t>, bp::args("filename"),
            "Saves *this inside a binary file.")
       .def("loadFromBinary", &exact_cubic_t::loadFromBinary<exact_cubic_t>, bp::args("filename"),
-           "Loads *this from a binary file.");
+           "Loads *this from a binary file.")
+      .def(bp::self == bp::self)
+      .def(bp::self != bp::self)
+      ;
 
   /** END exact_cubic curve**/
   /** BEGIN cubic_hermite_spline **/
@@ -747,7 +757,10 @@ BOOST_PYTHON_MODULE(curves) {
       .def("saveAsBinary", &cubic_hermite_spline_t::saveAsBinary<cubic_hermite_spline_t>, bp::args("filename"),
            "Saves *this inside a binary file.")
       .def("loadFromBinary", &cubic_hermite_spline_t::loadFromBinary<cubic_hermite_spline_t>, bp::args("filename"),
-           "Loads *this from a binary file.");
+           "Loads *this from a binary file.")
+      .def(bp::self == bp::self)
+      .def(bp::self != bp::self)
+      ;
 
   /** END cubic_hermite_spline **/
   /** BEGIN curve constraints**/
@@ -761,7 +774,10 @@ BOOST_PYTHON_MODULE(curves) {
   /** END curve constraints**/
   /** BEGIN bernstein polynomial**/
   class_<bernstein_t>("bernstein", init<const unsigned int, const unsigned int>())
-      .def("__call__", &bernstein_t::operator());
+      .def("__call__", &bernstein_t::operator())
+      .def(bp::self == bp::self)
+      .def(bp::self != bp::self)
+      ;
   /** END bernstein polynomial**/
 
   /** BEGIN SO3 Linear**/
@@ -791,6 +807,8 @@ BOOST_PYTHON_MODULE(curves) {
       "Saves *this inside a binary file.")
       .def("loadFromBinary",&SO3Linear_t::loadFromBinary<SO3Linear_t>,bp::args("filename"),
       "Loads *this from a binary file.")
+      .def(bp::self == bp::self)
+      .def(bp::self != bp::self)
       ;
 
   /** END  SO3 Linear**/
@@ -842,6 +860,8 @@ BOOST_PYTHON_MODULE(curves) {
       "Saves *this inside a binary file.")
       .def("loadFromBinary",&SE3Curve_t::loadFromBinary<SE3Curve_t>,bp::args("filename"),
       "Loads *this from a binary file.")
+      .def(bp::self == bp::self)
+      .def(bp::self != bp::self)
 #ifdef CURVES_WITH_PINOCCHIO_SUPPORT
       .def("__init__",
            make_constructor(&wrapSE3CurveFromSE3Pinocchio, default_call_policies(),

--- a/python/curves_python.cpp
+++ b/python/curves_python.cpp
@@ -403,6 +403,8 @@ BOOST_PYTHON_MODULE(curves) {
   class_<CurveWrapper, boost::noncopyable>("curve", no_init)
       .def("__call__", pure_virtual(&curve_abc_t::operator()), "Evaluate the curve at the given time.",
            args("self", "t"))
+      .def("__eq__", &curve_abc_t::operator==)
+      .def("__ne__", &curve_abc_t::operator!=)
       .def("derivate", pure_virtual(&curve_abc_t::derivate), "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_abc_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
@@ -425,6 +427,8 @@ BOOST_PYTHON_MODULE(curves) {
   class_<Curve3Wrapper, boost::noncopyable, bases<curve_abc_t> >("curve3", no_init)
       .def("__call__", pure_virtual(&curve_3_t::operator()), "Evaluate the curve at the given time.",
            args("self", "t"))
+      .def("__eq__", &curve_3_t::operator==)
+      .def("__ne__", &curve_3_t::operator!=)
       .def("derivate", pure_virtual(&curve_3_t::derivate), "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_3_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
@@ -435,6 +439,8 @@ BOOST_PYTHON_MODULE(curves) {
   class_<CurveRotationWrapper, boost::noncopyable, bases<curve_abc_t> >("curve_rotation", no_init)
       .def("__call__", pure_virtual(&curve_rotation_t::operator()), "Evaluate the curve at the given time.",
            args("self", "t"))
+      .def("__eq__", &curve_rotation_t::operator==)
+      .def("__ne__", &curve_rotation_t::operator!=)
       .def("derivate", pure_virtual(&curve_rotation_t::derivate),
            "Evaluate the derivative of order N of curve at time t.", args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_rotation_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))
@@ -445,6 +451,8 @@ BOOST_PYTHON_MODULE(curves) {
   class_<CurveSE3Wrapper, boost::noncopyable, bases<curve_abc_t> >("curve_SE3", no_init)
       .def("__call__", &se3Return, "Evaluate the curve at the given time. Return as an homogeneous matrix.",
            args("self", "t"))
+      .def("__eq__", &curve_SE3_t::operator==)
+      .def("__ne__", &curve_SE3_t::operator!=)
       .def("derivate", pure_virtual(&curve_SE3_t::derivate),
            "Evaluate the derivative of order N of curve at time t. Return as a vector 6.", args("self", "t", "N"))
       .def("compute_derivate", pure_virtual(&curve_rotation_t::compute_derivate_ptr),return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",  args("self", "N"))

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -1187,6 +1187,58 @@ class TestCurves(unittest.TestCase):
         se3_bin.loadFromBinary("serialization_curve")
         self.compareCurves(se3_curves,se3_bin)
 
+    def test_operatorEqual(self):
+        # test with bezier
+        waypoints = array([[1., 2., 3.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.]]).transpose()
+        a0 = bezier(waypoints)
+        a1 = bezier(waypoints, 0., 3.)
+        a2 = bezier(waypoints, 0., 3.)
+        self.assertTrue(a0 != a1)
+        self.assertTrue(a1 == a2)
+
+        # test with polynomials of degree 5
+        p0 = array([1., 3., -2.])
+        p1 = array([0.6, 2., 2.5])
+        dp0 = array([-6., 2., -1.])
+        dp1 = array([10., 10., 10.])
+        ddp0 = array([1., -7., 4.5])
+        ddp1 = array([6., -1., -4])
+        min = 1.
+        max = 2.5
+        pol_1 = polynomial(p0.reshape(-1,1), dp0.reshape(-1,1), ddp0.reshape(-1,1), p1.reshape(-1,1), dp1.reshape(-1,1), ddp1.reshape(-1,1), min, max)
+        pol_2 = polynomial(p0.reshape(-1,1), dp0.reshape(-1,1), ddp0.reshape(-1,1), p1.reshape(-1,1), dp1.reshape(-1,1), ddp1.reshape(-1,1), min, max)
+        pol_3 = polynomial(p1.reshape(-1,1), dp0.reshape(-1,1), ddp0.reshape(-1,1), p0.reshape(-1,1), dp1.reshape(-1,1), ddp1.reshape(-1,1), min, max)
+        self.assertTrue(pol_1 == pol_2)
+        self.assertTrue(pol_1 != pol_3)
+
+        # test with polynomial/bezier
+        pol_4 = polynomial(p0.reshape(-1,1), dp0.reshape(-1,1), p1.reshape(-1,1), dp1.reshape(-1,1), min, max)
+        b_4 = convert_to_bezier(pol_4)
+        self.assertTrue(pol_4 == b_4)
+        self.assertTrue(pol_4 != a1)
+
+        #test with SE3 :
+        init_quat = Quaternion.Identity()
+        end_quat = Quaternion(sqrt(2.) / 2., sqrt(2.) / 2., 0, 0)
+        init_rot = init_quat.matrix()
+        end_rot = end_quat.matrix()
+        waypoints = array([[1., 2., 3.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.], [4., 5., 6.]]).transpose()
+        min = 0.2
+        max = 1.5
+        translation = bezier(waypoints, min, max)
+        se3_1 = SE3Curve(translation, init_rot, end_rot)
+        se3_2 = SE3Curve(translation, init_rot, end_rot)
+        waypoints2 = array([[1., 2., 3.5], [4., 5., 6.], [-4, 5., 6.], [4., 8., 6.], [4., 5., 6.]]).transpose()
+        translation3 = bezier(waypoints2, min, max)
+        se3_3 = SE3Curve(translation3, init_rot, end_rot)
+        end_quat2 = Quaternion(sqrt(2.) / 2.,0.,  sqrt(2.) / 2., 0)
+        end_rot2 = end_quat2.matrix()
+        se3_4 = SE3Curve(translation, init_rot, end_rot2)
+        self.assertTrue(se3_1 == se3_2)
+        self.assertTrue(se3_1 != se3_3)
+        self.assertTrue(se3_1 != se3_4)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -1214,8 +1214,10 @@ class TestCurves(unittest.TestCase):
         # test with polynomial/bezier
         pol_4 = polynomial(p0.reshape(-1,1), dp0.reshape(-1,1), p1.reshape(-1,1), dp1.reshape(-1,1), min, max)
         b_4 = convert_to_bezier(pol_4)
-        self.assertTrue(pol_4 == b_4)
-        self.assertTrue(pol_4 != a1)
+        self.assertTrue(pol_4.isEquivalent(b_4))
+        self.assertTrue(pol_4.isEquivalent(b_4,1e-6))
+        self.assertTrue(pol_4.isEquivalent(b_4,1e-6,2))
+        self.assertFalse(pol_4.isEquivalent(a1))
 
         #test with SE3 :
         init_quat = Quaternion.Identity()
@@ -1237,7 +1239,6 @@ class TestCurves(unittest.TestCase):
         self.assertTrue(se3_1 == se3_2)
         self.assertTrue(se3_1 != se3_3)
         self.assertTrue(se3_1 != se3_4)
-
 
 
 if __name__ == '__main__':

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -257,8 +257,6 @@ class TestCurves(unittest.TestCase):
         ddp1 = array([6., -1., -4])
         min = 1.
         max = 2.5
-        # a reshape is required as the inputs must be of shape (n,1) and not (n,)
-        # p0 is equivalent to p0.reshape(len(p0),1)
         polC0 = polynomial(p0, p1, min, max)
         self.assertEqual(polC0.min(), min)
         self.assertEqual(polC0.max(), max)
@@ -1205,14 +1203,14 @@ class TestCurves(unittest.TestCase):
         ddp1 = array([6., -1., -4])
         min = 1.
         max = 2.5
-        pol_1 = polynomial(p0.reshape(-1,1), dp0.reshape(-1,1), ddp0.reshape(-1,1), p1.reshape(-1,1), dp1.reshape(-1,1), ddp1.reshape(-1,1), min, max)
-        pol_2 = polynomial(p0.reshape(-1,1), dp0.reshape(-1,1), ddp0.reshape(-1,1), p1.reshape(-1,1), dp1.reshape(-1,1), ddp1.reshape(-1,1), min, max)
-        pol_3 = polynomial(p1.reshape(-1,1), dp0.reshape(-1,1), ddp0.reshape(-1,1), p0.reshape(-1,1), dp1.reshape(-1,1), ddp1.reshape(-1,1), min, max)
+        pol_1 = polynomial(p0, dp0, ddp0, p1, dp1, ddp1, min, max)
+        pol_2 = polynomial(p0, dp0, ddp0, p1, dp1, ddp1, min, max)
+        pol_3 = polynomial(p1, dp0, ddp0, p0, dp1, ddp1, min, max)
         self.assertTrue(pol_1 == pol_2)
         self.assertTrue(pol_1 != pol_3)
 
         # test with polynomial/bezier
-        pol_4 = polynomial(p0.reshape(-1,1), dp0.reshape(-1,1), p1.reshape(-1,1), dp1.reshape(-1,1), min, max)
+        pol_4 = polynomial(p0, dp0, p1, dp1, min, max)
         b_4 = convert_to_bezier(pol_4)
         self.assertTrue(pol_4.isEquivalent(b_4))
         self.assertTrue(pol_4.isEquivalent(b_4,1e-6))

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -2518,6 +2518,10 @@ void testOperatorEqual(bool& error){
     std::cout<<"c_ptr2 and c_ptr3 should be equivalent"<<std::endl;
     error = true;
   }
+  if(c_ptr1->isApprox(c_ptr3.get())){
+    std::cout<<"c_ptr1 and c_ptr3 should not be approx"<<std::endl;
+    error = true;
+  }
 
 
   // SE3

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -2318,6 +2318,276 @@ void BezierLinearProblemsetupLoadProblem(bool& /*error*/) {
   // initInequalityMatrix<point_t,3,double>(pDef,pData,prob);
 }
 
+void testOperatorEqual(bool& error){
+  // test with a C2 polynomial :
+  pointX_t zeros = point3_t(0., 0., 0.);
+  pointX_t p0 = point3_t(0., 1., 0.);
+  pointX_t p1 = point3_t(1., 2., -3.);
+  pointX_t dp0 = point3_t(-8., 4., 6.);
+  pointX_t dp1 = point3_t(10., -10., 10.);
+  pointX_t ddp0 = point3_t(-1., 7., 4.);
+  pointX_t ddp1 = point3_t(12., -8., 2.5);
+  double min = 0.5;
+  double max = 2.;
+  polynomial_t polC2_1 = polynomial_t(p0, dp0, ddp0, p1, dp1, ddp1, min, max);
+  polynomial_t polC2_2 = polynomial_t(p0, dp0, ddp0, p1, dp1, ddp1, min, max);
+  polynomial_t polC2_3(polC2_1);
+
+  if(polC2_1 != polC2_2){
+    std::cout<<"polC2_1 and polC2_2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(polC2_1 != polC2_3){
+    std::cout<<"polC2_1 and polC2_3 should be equals"<<std::endl;
+    error = true;
+  }
+
+  polynomial_t polC2_4 = polynomial_t(p1, dp0, ddp0, p1, dp1, ddp0, min, max);
+  if(polC2_1 == polC2_4){
+    std::cout<<"polC2_1 and polC2_4 should not be equals"<<std::endl;
+    error = true;
+  }
+
+  // test with bezier
+  point3_t a(1, 2, 3);
+  point3_t b(2, 3, 4);
+  point3_t c(3, 4, 5);
+  point3_t d(3, 6, 7);
+  point3_t e(3, 61, 7);
+  point3_t f(3, 56, 7);
+  point3_t g(3, 36, 7);
+  point3_t h(43, 6, 7);
+  point3_t i(3, 6, 77);
+  std::vector<point3_t> control_points;
+  control_points.push_back(a);
+  control_points.push_back(b);
+  control_points.push_back(c);
+  control_points.push_back(d);
+  control_points.push_back(e);
+  control_points.push_back(f);
+  control_points.push_back(g);
+  control_points.push_back(h);
+  control_points.push_back(i);
+  bezier_t::num_t T_min = 1.0;
+  bezier_t::num_t T_max = 3.0;
+  bezier_t bc_0(control_points.begin(), control_points.end(), T_min, T_max);
+  bezier_t bc_1(bc_0);
+  if(bc_1 != bc_0){
+    std::cout<<"bc_0 and bc_1 should be equals"<<std::endl;
+    error = true;
+  }
+  std::vector<point3_t> control_points2;
+  control_points2.push_back(a);
+  control_points2.push_back(b);
+  control_points2.push_back(c);
+  control_points2.push_back(d);
+  bezier_t bc_2(control_points2.begin(), control_points2.end(), T_min, T_max);
+  if(bc_2 == bc_0){
+    std::cout<<"bc_0 and bc_2 should not be equals"<<std::endl;
+    error = true;
+  }
+  polynomial_t pol_2 = polynomial_from_curve<polynomial_t>(bc_2);
+  bezier_t bc_3 = bezier_from_curve<bezier_t>(pol_2);
+  if(bc_2 != bc_3){
+    std::cout<<"bc_2 and bc_3 should be equals"<<std::endl;
+    error = true;
+  }
+
+  // test bezier / polynomial
+  polynomial_t pol_0 = polynomial_from_curve<polynomial_t>(bc_0);
+  CompareCurves<polynomial_t,bezier_t>(pol_0,bc_0,"compare pol_0 and bc_0",error);
+  if(bc_0 != pol_0){
+    std::cout<<"bc_0 and pol_0 should be equals"<<std::endl;
+    error = true;
+  }
+
+  // test with hermite :
+  point3_t ch_p0(1, 2, 3);
+  point3_t ch_m0(2, 3, 4);
+  point3_t ch_p1(3, 4, 5);
+  point3_t ch_m1(3, 6, 7);
+  pair_point_tangent_t pair0(ch_p0, ch_m0);
+  pair_point_tangent_t pair1(ch_p1, ch_m1);
+  t_pair_point_tangent_t ch_control_points;
+  ch_control_points.push_back(pair0);
+  ch_control_points.push_back(pair1);
+  std::vector<double> time_control_points;
+  time_control_points.push_back(T_min);
+  time_control_points.push_back(T_max);
+  cubic_hermite_spline_t chs0(ch_control_points.begin(), ch_control_points.end(), time_control_points);
+  cubic_hermite_spline_t chs1(ch_control_points.begin(), ch_control_points.end(), time_control_points);
+  cubic_hermite_spline_t chs2(chs0);
+  point3_t ch_p2(3.1, 4, 5);
+  point3_t ch_m2(3, 6.5, 6.);
+  pair_point_tangent_t pair2(ch_p2, ch_m2);
+  t_pair_point_tangent_t ch_control_points2;
+  ch_control_points2.push_back(pair0);
+  ch_control_points2.push_back(pair2);
+  cubic_hermite_spline_t chs3(ch_control_points2.begin(), ch_control_points2.end(), time_control_points);
+  if(chs0 != chs1){
+    std::cout<<"chs0 and chs1 should be equals"<<std::endl;
+    error = true;
+  }
+  if(chs0 != chs2){
+    std::cout<<"chs0 and chs2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(chs0 == chs3){
+    std::cout<<"chs0 and chs3 should not be equals"<<std::endl;
+    error = true;
+  }
+
+//  // test bezier / hermite
+  bezier_t bc_ch = bezier_from_curve<bezier_t>(chs0);
+  if(chs0 != bc_ch){
+    std::cout<<"chs0 and bc_ch should be equals"<<std::endl;
+    error = true;
+  }
+  // test polynomial / hermite
+  polynomial_t pol_ch = polynomial_from_curve<polynomial_t>(chs0);
+  if(chs0 != pol_ch){
+    std::cout<<"chs0 and pol_ch should be equals"<<std::endl;
+    error = true;
+  }
+
+  // SO3
+  quaternion_t q0(1, 0, 0, 0);
+  quaternion_t q1(0.7071, 0.7071, 0, 0);
+  q0.normalize();
+  q1.normalize();
+  const double tMin = 0.;
+  const double tMax = 1.5;
+  SO3Linear_t so3Traj1(q0, q1, tMin, tMax);
+  SO3Linear_t so3Traj2(q0, q1, tMin, tMax);
+  SO3Linear_t so3TrajMatrix1(q0.toRotationMatrix(), q1.toRotationMatrix(), tMin, tMax);
+  SO3Linear_t so3TrajMatrix2(so3TrajMatrix1);
+  quaternion_t q2(0.7071, 0., 0.7071, 0);
+  q2.normalize();
+  SO3Linear_t so3Traj3(q0, q2, tMin, tMax);
+  if(so3Traj1 != so3Traj2){
+    std::cout<<"so3Traj1 and so3Traj2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(so3Traj1 != so3TrajMatrix1){
+    std::cout<<"so3Traj1 and so3TrajMatrix1 should be equals"<<std::endl;
+    error = true;
+  }
+  if(so3Traj1 != so3TrajMatrix2){
+    std::cout<<"so3Traj1 and so3TrajMatrix2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(so3Traj1 == so3Traj3){
+    std::cout<<"so3Traj1 and so3Traj3 should not be equals"<<std::endl;
+    error = true;
+  }
+
+  // SE3
+  boost::shared_ptr<bezier_t> translation_bezier(new bezier_t(bc_0));
+  boost::shared_ptr<polynomial_t> translation_polynomial(new polynomial_t(pol_0));
+  SE3Curve_t se3_bezier1 = SE3Curve_t(translation_bezier, q0.toRotationMatrix(), q1.toRotationMatrix());
+  SE3Curve_t se3_pol1 = SE3Curve_t(translation_polynomial, q0.toRotationMatrix(), q1.toRotationMatrix());
+  SE3Curve_t se3_bezier2(se3_bezier1);
+  SE3Curve_t se3_bezier3 = SE3Curve_t(translation_bezier, q0.toRotationMatrix(), q2.toRotationMatrix());
+  boost::shared_ptr<polynomial_t> translation_polynomial2(new polynomial_t(pol_2));
+  SE3Curve_t se3_pol2 = SE3Curve_t(translation_polynomial2, q0.toRotationMatrix(), q1.toRotationMatrix());
+  if(se3_bezier1 != se3_pol1){
+    std::cout<<"se3_bezier1 and se3_pol1 should be equals"<<std::endl;
+    error = true;
+  }
+  if(se3_bezier1 != se3_bezier2){
+    std::cout<<"se3_bezier1 and se3_bezier2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(se3_bezier1 == se3_pol2){
+    std::cout<<"se3_bezier1 and se3_pol2 should not be equals"<<std::endl;
+    error = true;
+  }
+  if(se3_bezier1 == se3_bezier3){
+    std::cout<<"se3_bezier1 and se3_bezier3 should not be equals"<<std::endl;
+    error = true;
+  }
+
+  // Piecewises
+  point3_t a0(1, 2, 3);
+  point3_t b0(2, 3, 4);
+  point3_t c0(3, 4, 5);
+  point3_t d0(4, 5, 6);
+  std::vector<point3_t> params0;
+  std::vector<point3_t> params1;
+  params0.push_back(a0);  // bezier between [0,1]
+  params0.push_back(b0);
+  params0.push_back(c0);
+  params0.push_back(d0);
+  params1.push_back(d0);  // bezier between [1,2]
+  params1.push_back(c0);
+  params1.push_back(b0);
+  params1.push_back(a0);
+  boost::shared_ptr<bezier_t> bc0_ptr(new bezier_t(params0.begin(), params0.end(), 0., 1.));
+  boost::shared_ptr<bezier_t> bc1_ptr(new bezier_t(params1.begin(), params1.end(), 1., 2.));
+  piecewise_t pc_C0(bc0_ptr);
+  pc_C0.add_curve_ptr(bc1_ptr);
+  piecewise_t pc_C1(bc0_ptr);
+  pc_C1.add_curve_ptr(bc1_ptr);
+  piecewise_t pc_C2(pc_C0);
+  piecewise_t pc_C3(bc0_ptr);
+  piecewise_t pc_C4(bc0_ptr);
+  boost::shared_ptr<bezier_t> bc2_ptr(new bezier_t(params0.begin(), params0.end(), 1., 2.));
+  pc_C4.add_curve_ptr(bc2_ptr);
+
+  if(pc_C0 != pc_C1){
+    std::cout<<"pc_C0 and pc_C1 should be equals"<<std::endl;
+    error = true;
+  }
+  if(pc_C0 != pc_C2){
+    std::cout<<"pc_C0 and pc_C2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(pc_C0 == pc_C3){
+    std::cout<<"pc_C0 and pc_C3 should not be equals"<<std::endl;
+    error = true;
+  }
+  if(pc_C0 == pc_C4){
+    std::cout<<"pc_C0 and pc_C4 should not be equals"<<std::endl;
+    error = true;
+  }
+  // piecewise with mixed curves types
+  piecewise_t pc_C5 =  pc_C0.convert_piecewise_curve_to_polynomial<polynomial_t>();
+  if(pc_C0 != pc_C5){
+    std::cout<<"pc_C0 and pc_C5 should be equals"<<std::endl;
+    error = true;
+  }
+
+  // piecewise se3 :
+  piecewise_SE3_t pc_se3_1;
+  pc_se3_1.add_curve(se3_pol1);
+  point3_t p_init_se3(translation_polynomial->operator()(translation_polynomial->max()));
+  point3_t dp_init_se3(translation_polynomial->derivate(translation_polynomial->max(),1));
+  point3_t p_end_se3(1,-2,6);
+  point3_t dp_end_se3(3.5,2.5,-9);
+  boost::shared_ptr<polynomial_t> translation_pol3(new polynomial_t(p_init_se3,dp_init_se3,p_end_se3,dp_end_se3,translation_polynomial->max(),translation_polynomial->max()+2.5));
+  curve_SE3_ptr_t se3_pol_3(new SE3Curve_t(translation_pol3,q1.toRotationMatrix(),q2.toRotationMatrix()));
+  pc_se3_1.add_curve_ptr(se3_pol_3);
+  piecewise_SE3_t pc_se3_2(pc_se3_1);
+  piecewise_SE3_t pc_se3_3(boost::make_shared<SE3Curve_t>(se3_pol1));
+  pc_se3_3.add_curve_ptr(se3_pol_3);
+  piecewise_SE3_t pc_se3_4(boost::make_shared<SE3Curve_t>(se3_pol2));
+  pc_se3_4.add_curve_ptr(se3_pol_3);
+
+  if(pc_se3_1 != pc_se3_2){
+    std::cout<<"pc_se3_1 and pc_se3_2 should be equals"<<std::endl;
+    error = true;
+  }
+  if(pc_se3_1 != pc_se3_3){
+    std::cout<<"pc_se3_1 and pc_se3_3 should be equals"<<std::endl;
+    error = true;
+  }
+  if(pc_se3_1 == pc_se3_4){
+    std::cout<<"pc_se3_1 and pc_se3_3 should not be equals"<<std::endl;
+    error = true;
+  }
+
+}
+
 int main(int /*argc*/, char** /*argv[]*/) {
   std::cout << "performing tests... \n";
   bool error = false;
@@ -2356,6 +2626,7 @@ int main(int /*argc*/, char** /*argv[]*/) {
   BezierLinearProblemsetup_control_pointsVarCombinatorialEnd(error);
   BezierLinearProblemsetup_control_pointsVarCombinatorialMix(error);
   BezierLinearProblemsetupLoadProblem(error);
+  testOperatorEqual(error);
 
   if (error) {
     std::cout << "There were some errors\n";

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -2387,6 +2387,24 @@ void testOperatorEqual(bool& error){
     std::cout<<"bc_0 and bc_2 should not be equals"<<std::endl;
     error = true;
   }
+
+  point3_t e3(3, 61.9, 7);
+  point3_t g3(-3, 36, 7);
+  std::vector<point3_t> control_points3;
+  control_points3.push_back(a);
+  control_points3.push_back(b);
+  control_points3.push_back(c);
+  control_points3.push_back(d);
+  control_points3.push_back(e3);
+  control_points3.push_back(f);
+  control_points3.push_back(g3);
+  control_points3.push_back(h);
+  control_points3.push_back(i);
+  bezier_t bc_0_3(control_points3.begin(), control_points3.end(), T_min, T_max);
+  if(bc_0_3 == bc_0){
+   std::cout<<"bc_0_3 and bc_0 should not be equals"<<std::endl;
+   error = true;
+  }
   polynomial_t pol_2 = polynomial_from_curve<polynomial_t>(bc_2);
   bezier_t bc_3 = bezier_from_curve<bezier_t>(pol_2);
   if(bc_2 != bc_3){

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -2332,7 +2332,7 @@ void testOperatorEqual(bool& error){
   polynomial_t polC2_1 = polynomial_t(p0, dp0, ddp0, p1, dp1, ddp1, min, max);
   polynomial_t polC2_2 = polynomial_t(p0, dp0, ddp0, p1, dp1, ddp1, min, max);
   polynomial_t polC2_3(polC2_1);
-
+  //std::cout<<"Should call polynomial method : "<<std::endl;
   if(polC2_1 != polC2_2){
     std::cout<<"polC2_1 and polC2_2 should be equals"<<std::endl;
     error = true;
@@ -2372,6 +2372,7 @@ void testOperatorEqual(bool& error){
   bezier_t::num_t T_max = 3.0;
   bezier_t bc_0(control_points.begin(), control_points.end(), T_min, T_max);
   bezier_t bc_1(bc_0);
+  //std::cout<<"Should call Bezier method : "<<std::endl;
   if(bc_1 != bc_0){
     std::cout<<"bc_0 and bc_1 should be equals"<<std::endl;
     error = true;
@@ -2396,6 +2397,7 @@ void testOperatorEqual(bool& error){
   // test bezier / polynomial
   polynomial_t pol_0 = polynomial_from_curve<polynomial_t>(bc_0);
   CompareCurves<polynomial_t,bezier_t>(pol_0,bc_0,"compare pol_0 and bc_0",error);
+  //std::cout<<"Should call curve_abc method : "<<std::endl;
   if(bc_0 != pol_0){
     std::cout<<"bc_0 and pol_0 should be equals"<<std::endl;
     error = true;
@@ -2424,6 +2426,7 @@ void testOperatorEqual(bool& error){
   ch_control_points2.push_back(pair0);
   ch_control_points2.push_back(pair2);
   cubic_hermite_spline_t chs3(ch_control_points2.begin(), ch_control_points2.end(), time_control_points);
+  //std::cout<<"Should call hermite method : "<<std::endl;
   if(chs0 != chs1){
     std::cout<<"chs0 and chs1 should be equals"<<std::endl;
     error = true;
@@ -2439,6 +2442,7 @@ void testOperatorEqual(bool& error){
 
 //  // test bezier / hermite
   bezier_t bc_ch = bezier_from_curve<bezier_t>(chs0);
+  //std::cout<<"Should call curve_abc method : "<<std::endl;
   if(chs0 != bc_ch){
     std::cout<<"chs0 and bc_ch should be equals"<<std::endl;
     error = true;
@@ -2464,6 +2468,7 @@ void testOperatorEqual(bool& error){
   quaternion_t q2(0.7071, 0., 0.7071, 0);
   q2.normalize();
   SO3Linear_t so3Traj3(q0, q2, tMin, tMax);
+  //std::cout<<"Should call SO3 method : "<<std::endl;
   if(so3Traj1 != so3Traj2){
     std::cout<<"so3Traj1 and so3Traj2 should be equals"<<std::endl;
     error = true;
@@ -2490,18 +2495,22 @@ void testOperatorEqual(bool& error){
   SE3Curve_t se3_bezier3 = SE3Curve_t(translation_bezier, q0.toRotationMatrix(), q2.toRotationMatrix());
   boost::shared_ptr<polynomial_t> translation_polynomial2(new polynomial_t(pol_2));
   SE3Curve_t se3_pol2 = SE3Curve_t(translation_polynomial2, q0.toRotationMatrix(), q1.toRotationMatrix());
+  //std::cout<<"Should call se3 -> curve_abc / so3 method : "<<std::endl;
   if(se3_bezier1 != se3_pol1){
     std::cout<<"se3_bezier1 and se3_pol1 should be equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call se3 -> bezier / so3 method : "<<std::endl;
   if(se3_bezier1 != se3_bezier2){
     std::cout<<"se3_bezier1 and se3_bezier2 should be equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call se3 -> curve_abc / so3 method : "<<std::endl;
   if(se3_bezier1 == se3_pol2){
     std::cout<<"se3_bezier1 and se3_pol2 should not be equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call se3 -> bezier / so3 method : "<<std::endl;
   if(se3_bezier1 == se3_bezier3){
     std::cout<<"se3_bezier1 and se3_bezier3 should not be equals"<<std::endl;
     error = true;
@@ -2533,7 +2542,7 @@ void testOperatorEqual(bool& error){
   piecewise_t pc_C4(bc0_ptr);
   boost::shared_ptr<bezier_t> bc2_ptr(new bezier_t(params0.begin(), params0.end(), 1., 2.));
   pc_C4.add_curve_ptr(bc2_ptr);
-
+  //std::cout<<"Should call curve_abc method : "<<std::endl;
   if(pc_C0 != pc_C1){
     std::cout<<"pc_C0 and pc_C1 should be equals"<<std::endl;
     error = true;

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -2415,9 +2415,9 @@ void testOperatorEqual(bool& error){
   // test bezier / polynomial
   polynomial_t pol_0 = polynomial_from_curve<polynomial_t>(bc_0);
   CompareCurves<polynomial_t,bezier_t>(pol_0,bc_0,"compare pol_0 and bc_0",error);
-  //std::cout<<"Should call curve_abc method : "<<std::endl;
-  if(bc_0 != pol_0){
-    std::cout<<"bc_0 and pol_0 should be equals"<<std::endl;
+  std::cout<<"Should call curve_abc method : "<<std::endl;
+  if(!bc_0.isApprox(pol_0)){
+    std::cout<<"bc_0 and pol_0 should be approx"<<std::endl;
     error = true;
   }
 
@@ -2460,15 +2460,15 @@ void testOperatorEqual(bool& error){
 
 //  // test bezier / hermite
   bezier_t bc_ch = bezier_from_curve<bezier_t>(chs0);
-  //std::cout<<"Should call curve_abc method : "<<std::endl;
-  if(chs0 != bc_ch){
-    std::cout<<"chs0 and bc_ch should be equals"<<std::endl;
+  std::cout<<"Should call curve_abc method : "<<std::endl;
+  if(!chs0.isApprox(bc_ch)){
+    std::cout<<"chs0 and bc_ch should be approx"<<std::endl;
     error = true;
   }
   // test polynomial / hermite
   polynomial_t pol_ch = polynomial_from_curve<polynomial_t>(chs0);
-  if(chs0 != pol_ch){
-    std::cout<<"chs0 and pol_ch should be equals"<<std::endl;
+  if(!chs0.isApprox(pol_ch)){
+    std::cout<<"chs0 and pol_ch should be approx"<<std::endl;
     error = true;
   }
 
@@ -2504,10 +2504,28 @@ void testOperatorEqual(bool& error){
     error = true;
   }
 
+  // test from pointer :
+  curve_ptr_t c_ptr1(new bezier_t(bc_0));
+  curve_ptr_t c_ptr2(new bezier_t(bc_0));
+  curve_ptr_t c_ptr3(new polynomial_t(pol_0));
+  std::cout<<"Should call bezier method : "<<std::endl;
+  if(!c_ptr1->isApprox(*c_ptr2)){
+    std::cout<<"c_ptr1 and c_ptr2 should be approx"<<std::endl;
+    error = true;
+  }
+  std::cout<<"Should call curve_abc method : "<<std::endl;
+  if(!c_ptr2->isApprox(*c_ptr3)){
+    std::cout<<"c_ptr2 and c_ptr3 should be approx"<<std::endl;
+    error = true;
+  }
+
+
   // SE3
-  boost::shared_ptr<bezier_t> translation_bezier(new bezier_t(bc_0));
+  boost::shared_ptr<bezier_t> translation_bezier(new bezier_t(bc_0)); 
+  boost::shared_ptr<bezier_t> translation_bezier2(new bezier_t(bc_0));
   boost::shared_ptr<polynomial_t> translation_polynomial(new polynomial_t(pol_0));
   SE3Curve_t se3_bezier1 = SE3Curve_t(translation_bezier, q0.toRotationMatrix(), q1.toRotationMatrix());
+  SE3Curve_t se3_bezier12 = SE3Curve_t(translation_bezier2, q0.toRotationMatrix(), q1.toRotationMatrix());
   SE3Curve_t se3_pol1 = SE3Curve_t(translation_polynomial, q0.toRotationMatrix(), q1.toRotationMatrix());
   SE3Curve_t se3_bezier2(se3_bezier1);
   SE3Curve_t se3_bezier3 = SE3Curve_t(translation_bezier, q0.toRotationMatrix(), q2.toRotationMatrix());
@@ -2523,7 +2541,12 @@ void testOperatorEqual(bool& error){
     std::cout<<"se3_bezier1 and se3_bezier2 should be equals"<<std::endl;
     error = true;
   }
-  //std::cout<<"Should call se3 -> curve_abc / so3 method : "<<std::endl;
+  std::cout<<"Should call se3 -> bezier / SO3 method : "<<std::endl;
+  if(se3_bezier1 != se3_bezier12){
+    std::cout<<"se3_bezier1 and se3_bezier12 should be equals"<<std::endl;
+    error = true;
+  }
+  std::cout<<"Should call se3 -> curve_abc : "<<std::endl;
   if(se3_bezier1 == se3_pol2){
     std::cout<<"se3_bezier1 and se3_pol2 should not be equals"<<std::endl;
     error = true;

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -2415,9 +2415,9 @@ void testOperatorEqual(bool& error){
   // test bezier / polynomial
   polynomial_t pol_0 = polynomial_from_curve<polynomial_t>(bc_0);
   CompareCurves<polynomial_t,bezier_t>(pol_0,bc_0,"compare pol_0 and bc_0",error);
-  std::cout<<"Should call curve_abc method : "<<std::endl;
-  if(!bc_0.isApprox(pol_0)){
-    std::cout<<"bc_0 and pol_0 should be approx"<<std::endl;
+  //std::cout<<"Should call curve_abc method : "<<std::endl;
+  if(!bc_0.isEquivalent(&pol_0)){
+    std::cout<<"bc_0 and pol_0 should be equivalent"<<std::endl;
     error = true;
   }
 
@@ -2460,15 +2460,15 @@ void testOperatorEqual(bool& error){
 
 //  // test bezier / hermite
   bezier_t bc_ch = bezier_from_curve<bezier_t>(chs0);
-  std::cout<<"Should call curve_abc method : "<<std::endl;
-  if(!chs0.isApprox(bc_ch)){
-    std::cout<<"chs0 and bc_ch should be approx"<<std::endl;
+  //std::cout<<"Should call curve_abc method : "<<std::endl;
+  if(!chs0.isEquivalent(&bc_ch)){
+    std::cout<<"chs0 and bc_ch should be equivalent"<<std::endl;
     error = true;
   }
   // test polynomial / hermite
   polynomial_t pol_ch = polynomial_from_curve<polynomial_t>(chs0);
-  if(!chs0.isApprox(pol_ch)){
-    std::cout<<"chs0 and pol_ch should be approx"<<std::endl;
+  if(!chs0.isEquivalent(&pol_ch)){
+    std::cout<<"chs0 and pol_ch should be equivalent"<<std::endl;
     error = true;
   }
 
@@ -2506,16 +2506,16 @@ void testOperatorEqual(bool& error){
 
   // test from pointer :
   curve_ptr_t c_ptr1(new bezier_t(bc_0));
-  curve_ptr_t c_ptr2(new bezier_t(bc_0));
+  curve_abc_t* c_ptr2 = new bezier_t(bc_0);
   curve_ptr_t c_ptr3(new polynomial_t(pol_0));
-  std::cout<<"Should call bezier method : "<<std::endl;
-  if(!c_ptr1->isApprox(*c_ptr2)){
+  //std::cout<<"Should call bezier method : "<<std::endl;
+  if(!c_ptr1->isApprox(c_ptr2)){
     std::cout<<"c_ptr1 and c_ptr2 should be approx"<<std::endl;
     error = true;
   }
-  std::cout<<"Should call curve_abc method : "<<std::endl;
-  if(!c_ptr2->isApprox(*c_ptr3)){
-    std::cout<<"c_ptr2 and c_ptr3 should be approx"<<std::endl;
+  //std::cout<<"Should call curve_abc method : "<<std::endl;
+  if(!c_ptr2->isEquivalent(c_ptr3.get())){
+    std::cout<<"c_ptr2 and c_ptr3 should be equivalent"<<std::endl;
     error = true;
   }
 
@@ -2531,27 +2531,36 @@ void testOperatorEqual(bool& error){
   SE3Curve_t se3_bezier3 = SE3Curve_t(translation_bezier, q0.toRotationMatrix(), q2.toRotationMatrix());
   boost::shared_ptr<polynomial_t> translation_polynomial2(new polynomial_t(pol_2));
   SE3Curve_t se3_pol2 = SE3Curve_t(translation_polynomial2, q0.toRotationMatrix(), q1.toRotationMatrix());
-  //std::cout<<"Should call se3 -> curve_abc / so3 method : "<<std::endl;
-  if(se3_bezier1 != se3_pol1){
-    std::cout<<"se3_bezier1 and se3_pol1 should be equals"<<std::endl;
+  //std::cout<<"Should call se3 method : "<<std::endl;
+  if(se3_bezier1 == se3_pol1){
+    std::cout<<"se3_bezier1 and se3_pol1 should not be equals"<<std::endl;
     error = true;
   }
-  //std::cout<<"Should call se3 -> bezier / so3 method : "<<std::endl;
+  if(se3_bezier1.isApprox(se3_pol1)){
+    std::cout<<"se3_bezier1 and se3_pol1 should not be approx"<<std::endl;
+    error = true;
+  }
+  //std::cout<<"Should call curve_abc : "<<std::endl;
+  if(!se3_bezier1.isEquivalent(&se3_pol1)){
+    std::cout<<"se3_bezier1 and se3_pol1 should be equivalent"<<std::endl;
+    error = true;
+  }
+  //std::cout<<"Should call se3 method : "<<std::endl;
   if(se3_bezier1 != se3_bezier2){
     std::cout<<"se3_bezier1 and se3_bezier2 should be equals"<<std::endl;
     error = true;
   }
-  std::cout<<"Should call se3 -> bezier / SO3 method : "<<std::endl;
+  //std::cout<<"Should call se3 -> bezier / SO3 method : "<<std::endl;
   if(se3_bezier1 != se3_bezier12){
     std::cout<<"se3_bezier1 and se3_bezier12 should be equals"<<std::endl;
     error = true;
   }
-  std::cout<<"Should call se3 -> curve_abc : "<<std::endl;
+  //std::cout<<"Should call se3 -> curve_abc : "<<std::endl;
   if(se3_bezier1 == se3_pol2){
     std::cout<<"se3_bezier1 and se3_pol2 should not be equals"<<std::endl;
     error = true;
   }
-  //std::cout<<"Should call se3 -> bezier / so3 method : "<<std::endl;
+  //std::cout<<"Should call se3 -> so3 method : "<<std::endl;
   if(se3_bezier1 == se3_bezier3){
     std::cout<<"se3_bezier1 and se3_bezier3 should not be equals"<<std::endl;
     error = true;
@@ -2583,29 +2592,39 @@ void testOperatorEqual(bool& error){
   piecewise_t pc_C4(bc0_ptr);
   boost::shared_ptr<bezier_t> bc2_ptr(new bezier_t(params0.begin(), params0.end(), 1., 2.));
   pc_C4.add_curve_ptr(bc2_ptr);
-  //std::cout<<"Should call curve_abc method : "<<std::endl;
+  //std::cout<<"Should call piecewise method -> bezier , bezier: "<<std::endl;
   if(pc_C0 != pc_C1){
     std::cout<<"pc_C0 and pc_C1 should be equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call piecewise method -> bezier , bezier: "<<std::endl;
   if(pc_C0 != pc_C2){
     std::cout<<"pc_C0 and pc_C2 should be equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call piecewise method: "<<std::endl;
   if(pc_C0 == pc_C3){
     std::cout<<"pc_C0 and pc_C3 should not be equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call piecewise method -> bezier , bezier: "<<std::endl;
   if(pc_C0 == pc_C4){
     std::cout<<"pc_C0 and pc_C4 should not be equals"<<std::endl;
     error = true;
   }
   // piecewise with mixed curves types
+  //std::cout<<"Should call piecewise method: "<<std::endl;
   piecewise_t pc_C5 =  pc_C0.convert_piecewise_curve_to_polynomial<polynomial_t>();
-  if(pc_C0 != pc_C5){
-    std::cout<<"pc_C0 and pc_C5 should be equals"<<std::endl;
+  if(pc_C0 == pc_C5){
+    std::cout<<"pc_C0 and pc_C5 should be not equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call curve_abc method: "<<std::endl;
+  if(!pc_C0.isEquivalent(&pc_C5)){
+    std::cout<<"pc_C0 and pc_C5 should be equivalents"<<std::endl;
+    error = true;
+  }
+
 
   // piecewise se3 :
   piecewise_SE3_t pc_se3_1;
@@ -2622,15 +2641,17 @@ void testOperatorEqual(bool& error){
   pc_se3_3.add_curve_ptr(se3_pol_3);
   piecewise_SE3_t pc_se3_4(boost::make_shared<SE3Curve_t>(se3_pol2));
   pc_se3_4.add_curve_ptr(se3_pol_3);
-
+  //std::cout<<"Should call piecewise method -> SE3 , SE3: "<<std::endl;
   if(pc_se3_1 != pc_se3_2){
     std::cout<<"pc_se3_1 and pc_se3_2 should be equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call piecewise method -> SE3 , SE3: "<<std::endl;
   if(pc_se3_1 != pc_se3_3){
     std::cout<<"pc_se3_1 and pc_se3_3 should be equals"<<std::endl;
     error = true;
   }
+  //std::cout<<"Should call piecewise method -> SE3  -> polynomial : "<<std::endl;
   if(pc_se3_1 == pc_se3_4){
     std::cout<<"pc_se3_1 and pc_se3_3 should not be equals"<<std::endl;
     error = true;


### PR DESCRIPTION
Solve issue https://gepgitlab.laas.fr/loco-3d/curves/issues/28

This PR add the method `isApprox` and the operator `==` and `!=` to `curve_abc` and reimplement it in most of the child class. 
The operator `==` in `curve_abc` check if two generic curves are equal **by value** ie. if the evaluate and derivate method of both curves return the same value along all the curve (using discretization). 
In the child class, the operator `==` check exactly if the two curves of the same type are the same (ie. by checking the coefficients values in a polynomial or the control points in a Bezier).

This choice of implementing a generic equality test between any kind of curves was made because two curves could represent the exact same trajectory using two different formulations (see the unit tests). But maybe this kind of curves should not be considered as _equal_ and this test should only be done in the  `isApprox` method ? 



This PR also add the python binding of the operator `==` and `!=` and unit tests in C++ and Python.

 
