### PR TITLE
[Python] Fix issue #32

### DIFF
--- a/include/curves/piecewise_curve.h
+++ b/include/curves/piecewise_curve.h
@@ -212,9 +212,9 @@ struct piecewise_curve : public curve_abc<Time, Numeric, Safe, Point, Point_deri
 
   std::size_t num_curves() const { return curves_.size(); }
 
-  const curve_ptr_t& curve_at_time(const time_t t) const { return curves_[find_interval(t)]; }
+  curve_ptr_t curve_at_time(const time_t t) const { return curves_[find_interval(t)]; }
 
-  const curve_ptr_t& curve_at_index(const std::size_t idx) const {
+  curve_ptr_t curve_at_index(const std::size_t idx) const {
     if (Safe && idx >= num_curves()) {
       throw std::length_error(
           "curve_at_index: requested index greater than number of curves in piecewise_curve instance");

--- a/python/curves/curves_python.cpp
+++ b/python/curves/curves_python.cpp
@@ -8,48 +8,76 @@
 #include "optimization_python.h"
 
 #include <boost/python.hpp>
+#include <boost/python/class.hpp>
+#include <boost/python/module_init.hpp>
+#include <boost/python/def.hpp>
+#include <boost/python/call_method.hpp>
+#include <boost/ref.hpp>
+#include <boost/utility.hpp>
 
 namespace curves {
 using namespace boost::python;
 
 /* base wrap of curve_abc and others parent abstract class: must implement all pure virtual methods */
-struct CurveWrapper : curve_abc_t, wrapper<curve_abc_t> {
-  point_t operator()(const real) { return this->get_override("operator()")(); }
-  point_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
-  curve_t* compute_derivate_ptr(const real) { return this->get_override("compute_derivate")(); }
-  std::size_t dim() { return this->get_override("dim")(); }
-  real min() { return this->get_override("min")(); }
-  real max() { return this->get_override("max")(); }
+struct curve_abc_callback : curve_abc_t {
+  curve_abc_callback(PyObject *p) : self(p) {}
+  virtual point_t operator()(const real t) const { return call_method<point_t>(self, "operator()", t); }
+  virtual point_t derivate(const real t, const std::size_t n) const  { return call_method<point_t>(self, "derivate", t, n); }
+  virtual curve_t* compute_derivate_ptr(const std::size_t n) const  { return call_method<curve_t*>(self, "compute_derivate", n); }
+  virtual std::size_t dim() const  { return call_method<std::size_t>(self, "dim"); }
+  virtual real min() const  { return call_method<real>(self,"min"); }
+  virtual real max() const  { return call_method<real>(self,"max"); }
+  virtual std::size_t degree() const  { return call_method<std::size_t>(self,"degree"); }
+  virtual bool isApprox(const curve_t* other, const real prec = Eigen::NumTraits<real>::dummy_precision()) const
+  {return call_method<bool>(self,"isApprox", other, prec); }
+  PyObject *self;
 };
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(curve_abc_t_isEquivalent_overloads, curve_abc_t::isEquivalent, 1, 3)
 
-struct Curve3Wrapper : curve_3_t, wrapper<curve_3_t> {
-  point3_t operator()(const real) { return this->get_override("operator()")(); }
-  point3_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
-  curve_t* compute_derivate_ptr(const real) { return this->get_override("compute_derivate")(); }
-  std::size_t dim() { return this->get_override("dim")(); }
-  real min() { return this->get_override("min")(); }
-  real max() { return this->get_override("max")(); }
+struct curve_3_callback : curve_3_t {
+  curve_3_callback(PyObject *p) : self(p) {}
+  virtual point3_t operator()(const real t) const { return call_method<point3_t>(self, "operator()", t); }
+  virtual point3_t derivate(const real t, const std::size_t n) const { return call_method<point3_t>(self, "derivate", t, n); }
+  virtual curve_t* compute_derivate_ptr(const std::size_t n) const { return call_method<curve_t*>(self, "compute_derivate", n); }
+  virtual std::size_t dim() const { return call_method<std::size_t>(self, "dim"); }
+  virtual real min() const { return call_method<real>(self,"min"); }
+  virtual real max() const { return call_method<real>(self,"max"); }
+  virtual std::size_t degree() const  { return call_method<std::size_t>(self,"degree"); }
+  virtual bool isApprox(const curve_t* other, const real prec = Eigen::NumTraits<real>::dummy_precision()) const
+  {return call_method<bool>(self,"isApprox", other, prec); }
+  PyObject *self;
 };
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(curve_3_t_isEquivalent_overloads, curve_3_t::isEquivalent, 1, 3)
 
-struct CurveRotationWrapper : curve_rotation_t, wrapper<curve_rotation_t> {
-  curve_rotation_t::point_t operator()(const real) { return this->get_override("operator()")(); }
-  curve_rotation_t::point_derivate_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
-  curve_t* compute_derivate_ptr(const real) { return this->get_override("compute_derivate")(); }
-  std::size_t dim() { return this->get_override("dim")(); }
-  real min() { return this->get_override("min")(); }
-  real max() { return this->get_override("max")(); }
+struct curve_rotation_callback : curve_rotation_t {
+  curve_rotation_callback(PyObject *p) : self(p) {}
+  virtual curve_rotation_t::point_t operator()(const real t) const { return call_method<curve_rotation_t::point_t>(self, "operator()", t); }
+  virtual curve_rotation_t::point_derivate_t derivate(const real t, const std::size_t n) const
+{ return call_method<curve_rotation_t::point_derivate_t>(self, "derivate", t, n); }
+  virtual curve_t* compute_derivate_ptr(const std::size_t n) const { return call_method<curve_t*>(self, "compute_derivate", n); }
+  virtual std::size_t dim() const { return call_method<std::size_t>(self, "dim"); }
+  virtual real min() const { return call_method<real>(self,"min"); }
+  virtual real max() const { return call_method<real>(self,"max"); }
+  virtual std::size_t degree() const  { return call_method<std::size_t>(self,"degree"); }
+  virtual bool isApprox(const curve_t* other, const real prec = Eigen::NumTraits<real>::dummy_precision()) const
+  {return call_method<bool>(self,"isApprox", other, prec); }
+  PyObject *self;
 };
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(curve_rotation_t_isEquivalent_overloads, curve_rotation_t::isEquivalent, 1, 3)
 
-struct CurveSE3Wrapper : curve_SE3_t, wrapper<curve_SE3_t> {
-  curve_SE3_t::point_t operator()(const real) { return this->get_override("operator()")(); }
-  curve_SE3_t::point_derivate_t derivate(const real, const std::size_t) { return this->get_override("derivate")(); }
-  curve_t* compute_derivate_ptr(const real) { return this->get_override("compute_derivate")(); }
-  std::size_t dim() { return this->get_override("dim")(); }
-  real min() { return this->get_override("min")(); }
-  real max() { return this->get_override("max")(); }
+struct curve_SE3_callback : curve_SE3_t {
+  curve_SE3_callback(PyObject *p) : self(p) {}
+  virtual curve_SE3_t::point_t operator()(const real t) const { return call_method<curve_SE3_t::point_t>(self, "operator()", t); }
+  virtual curve_SE3_t::point_derivate_t derivate(const real t, const std::size_t n) const
+  { return call_method<curve_SE3_t::point_derivate_t>(self, "derivate", t, n); }
+  virtual curve_t* compute_derivate_ptr(const std::size_t n) const { return call_method<curve_t*>(self, "compute_derivate", n); }
+  virtual std::size_t dim() const { return call_method<std::size_t>(self, "dim"); }
+  virtual real min() const { return call_method<real>(self,"min"); }
+  virtual real max() const { return call_method<real>(self,"max"); }
+  virtual std::size_t degree() const  { return call_method<std::size_t>(self,"degree"); }
+  virtual bool isApprox(const curve_t* other, const real prec = Eigen::NumTraits<real>::dummy_precision()) const
+  {return call_method<bool>(self,"isApprox", other, prec); }
+  PyObject *self;
 };
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(curve_SE3_t_isEquivalent_overloads, curve_SE3_t::isEquivalent, 1, 3)
 
@@ -432,21 +460,21 @@ BOOST_PYTHON_MODULE(curves) {
   /*eigenpy::exposeAngleAxis();
   eigenpy::exposeQuaternion();*/
   /** END eigenpy init**/
-  class_<CurveWrapper, boost::noncopyable, boost::shared_ptr<curve_abc_t> >("curve", no_init)
-      .def("__call__", pure_virtual(&curve_abc_t::operator()), "Evaluate the curve at the given time.",
+  class_<curve_abc_t, boost::noncopyable, boost::shared_ptr<curve_abc_callback> >("curve")
+      .def("__call__", &curve_abc_t::operator(), "Evaluate the curve at the given time.",
            args("self", "t"))
-      .def("derivate", pure_virtual(&curve_abc_t::derivate), "Evaluate the derivative of order N of curve at time t.",
+      .def("derivate", &curve_abc_t::derivate, "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
       .def("isEquivalent", &curve_abc_t::isEquivalent,
            curve_abc_t_isEquivalent_overloads(
                (bp::arg("other"), bp::arg("prec") = Eigen::NumTraits<double>::dummy_precision(), bp::arg("order") = 5),
                "isEquivalent check if self and other are approximately equal by values, given a precision treshold."))
-      .def("compute_derivate", pure_virtual(&curve_abc_t::compute_derivate_ptr),
+      .def("compute_derivate", &curve_abc_t::compute_derivate_ptr,
            return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",
            args("self", "N"))
-      .def("min", pure_virtual(&curve_abc_t::min), "Get the LOWER bound on interval definition of the curve.")
-      .def("max", pure_virtual(&curve_abc_t::max), "Get the HIGHER bound on interval definition of the curve.")
-      .def("dim", pure_virtual(&curve_abc_t::dim), "Get the dimension of the curve.")
+      .def("min", &curve_abc_t::min, "Get the LOWER bound on interval definition of the curve.")
+      .def("max", &curve_abc_t::max, "Get the HIGHER bound on interval definition of the curve.")
+      .def("dim", &curve_abc_t::dim, "Get the dimension of the curve.")
       .def("saveAsText", pure_virtual(&curve_abc_t::saveAsText<curve_abc_t>), bp::args("filename"),
            "Saves *this inside a text file.")
       .def("loadFromText", pure_virtual(&curve_abc_t::loadFromText<curve_abc_t>), bp::args("filename"),
@@ -460,53 +488,53 @@ BOOST_PYTHON_MODULE(curves) {
       .def("loadFromBinary", pure_virtual(&curve_abc_t::loadFromBinary<curve_abc_t>), bp::args("filename"),
            "Loads *this from a binary file.");
 
-  class_<Curve3Wrapper, boost::noncopyable, bases<curve_abc_t>, boost::shared_ptr<curve_3_t> >("curve3", no_init)
-      .def("__call__", pure_virtual(&curve_3_t::operator()), "Evaluate the curve at the given time.",
+  class_<curve_3_t, boost::noncopyable, bases<curve_abc_t>, boost::shared_ptr<curve_3_callback> >("curve3")
+      .def("__call__", &curve_3_t::operator(), "Evaluate the curve at the given time.",
            args("self", "t"))
-      .def("derivate", pure_virtual(&curve_3_t::derivate), "Evaluate the derivative of order N of curve at time t.",
+      .def("derivate", &curve_3_t::derivate, "Evaluate the derivative of order N of curve at time t.",
            args("self", "t", "N"))
       .def("isEquivalent", &curve_3_t::isEquivalent,
            curve_3_t_isEquivalent_overloads(
                (bp::arg("other"), bp::arg("prec") = Eigen::NumTraits<double>::dummy_precision(), bp::arg("order") = 5),
                "isEquivalent check if self and other are approximately equal by values, given a precision treshold."))
-      .def("compute_derivate", pure_virtual(&curve_3_t::compute_derivate_ptr),
+      .def("compute_derivate", &curve_3_t::compute_derivate_ptr,
            return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",
            args("self", "N"))
-      .def("min", pure_virtual(&curve_3_t::min), "Get the LOWER bound on interval definition of the curve.")
-      .def("max", pure_virtual(&curve_3_t::max), "Get the HIGHER bound on interval definition of the curve.")
-      .def("dim", pure_virtual(&curve_3_t::dim), "Get the dimension of the curve.");
+      .def("min", &curve_3_t::min, "Get the LOWER bound on interval definition of the curve.")
+      .def("max", &curve_3_t::max, "Get the HIGHER bound on interval definition of the curve.")
+      .def("dim", &curve_3_t::dim, "Get the dimension of the curve.");
 
-  class_<CurveRotationWrapper, boost::noncopyable, bases<curve_abc_t>, boost::shared_ptr<curve_rotation_t> >("curve_rotation", no_init)
-      .def("__call__", pure_virtual(&curve_rotation_t::operator()), "Evaluate the curve at the given time.",
+  class_<curve_rotation_t, boost::noncopyable, bases<curve_abc_t>, boost::shared_ptr<curve_rotation_callback> >("curve_rotation")
+      .def("__call__", &curve_rotation_t::operator(), "Evaluate the curve at the given time.",
            args("self", "t"))
-      .def("derivate", pure_virtual(&curve_rotation_t::derivate),
+      .def("derivate", &curve_rotation_t::derivate,
            "Evaluate the derivative of order N of curve at time t.", args("self", "t", "N"))
       .def("isEquivalent", &curve_rotation_t::isEquivalent,
            curve_rotation_t_isEquivalent_overloads(
                (bp::arg("other"), bp::arg("prec") = Eigen::NumTraits<double>::dummy_precision(), bp::arg("order") = 5),
                "isEquivalent check if self and other are approximately equal by values, given a precision treshold."))
-      .def("compute_derivate", pure_virtual(&curve_rotation_t::compute_derivate_ptr),
+      .def("compute_derivate", &curve_rotation_t::compute_derivate_ptr,
            return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",
            args("self", "N"))
-      .def("min", pure_virtual(&curve_rotation_t::min), "Get the LOWER bound on interval definition of the curve.")
-      .def("max", pure_virtual(&curve_rotation_t::max), "Get the HIGHER bound on interval definition of the curve.")
-      .def("dim", pure_virtual(&curve_rotation_t::dim), "Get the dimension of the curve.");
+      .def("min", &curve_rotation_t::min, "Get the LOWER bound on interval definition of the curve.")
+      .def("max", &curve_rotation_t::max, "Get the HIGHER bound on interval definition of the curve.")
+      .def("dim", &curve_rotation_t::dim, "Get the dimension of the curve.");
 
-  class_<CurveSE3Wrapper, boost::noncopyable, bases<curve_abc_t>, boost::shared_ptr<curve_SE3_t> >("curve_SE3", no_init)
+  class_<curve_SE3_t, boost::noncopyable, bases<curve_abc_t>, boost::shared_ptr<curve_SE3_callback> >("curve_SE3")
       .def("__call__", &se3Return, "Evaluate the curve at the given time. Return as an homogeneous matrix.",
            args("self", "t"))
-      .def("derivate", pure_virtual(&curve_SE3_t::derivate),
+      .def("derivate", &curve_SE3_t::derivate,
            "Evaluate the derivative of order N of curve at time t. Return as a vector 6.", args("self", "t", "N"))
       .def("isEquivalent", &curve_SE3_t::isEquivalent,
            curve_SE3_t_isEquivalent_overloads(
                (bp::arg("other"), bp::arg("prec") = Eigen::NumTraits<double>::dummy_precision(), bp::arg("order") = 5),
                "isEquivalent check if self and other are approximately equal by values, given a precision treshold."))
-      .def("compute_derivate", pure_virtual(&curve_SE3_t::compute_derivate_ptr),
+      .def("compute_derivate", &curve_SE3_t::compute_derivate_ptr,
            return_value_policy<manage_new_object>(), "Return the derivative of *this at the order N.",
            args("self", "N"))
-      .def("min", pure_virtual(&curve_SE3_t::min), "Get the LOWER bound on interval definition of the curve.")
-      .def("max", pure_virtual(&curve_SE3_t::max), "Get the HIGHER bound on interval definition of the curve.")
-      .def("dim", pure_virtual(&curve_SE3_t::dim), "Get the dimension of the curve.")
+      .def("min", &curve_SE3_t::min, "Get the LOWER bound on interval definition of the curve.")
+      .def("max", &curve_SE3_t::max, "Get the HIGHER bound on interval definition of the curve.")
+      .def("dim", &curve_SE3_t::dim, "Get the dimension of the curve.")
       .def("rotation", &se3returnRotation, "Output the rotation (as a 3x3 matrix) at the given time.",
            args("self", "time"))
       .def("translation", &se3returnTranslation, "Output the rotation (as a vector 3) at the given time.",

--- a/python/curves/curves_python.cpp
+++ b/python/curves/curves_python.cpp
@@ -240,13 +240,6 @@ static piecewise_t discretPointToPolynomialC2(const pointX_list_t& points, const
       points_list, points_derivative_list, points_second_derivative_list, time_points_list);
 }
 
-curve_abc_t* getCurveAtIndex(piecewise_t& self, const std::size_t idx){
-  return self.curve_at_index(idx).get();
-}
-
-curve_abc_t* getCurveAtTime(piecewise_t& self, const time_t t){
-  return self.curve_at_time(t).get();
-}
 
 void addFinalPointC0(piecewise_t& self, const pointX_t& end, const real time) {
   if (self.num_curves() == 0)
@@ -393,13 +386,6 @@ SE3Curve_t* wrapSE3CurveFromTwoCurves(const curve_ptr_t& translation_curve,
   return new SE3Curve_t(translation_curve, rotation_curve);
 }
 
-curve_abc_t* SE3getTranslationCurve(SE3Curve_t& self){
-  return self.translation_curve().get();
-}
-
-curve_rotation_t* SE3getRotationCurve(SE3Curve_t& self){
-  return self.rotation_curve().get();
-}
 
 #ifdef CURVES_WITH_PINOCCHIO_SUPPORT
 typedef pinocchio::SE3Tpl<real, 0> SE3_t;
@@ -756,8 +742,8 @@ BOOST_PYTHON_MODULE(curves) {
       .def("convert_piecewise_curve_to_cubic_hermite",
            &piecewise_t::convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>,
            "Convert a piecewise curve to to a piecewise cubic hermite spline")
-      .def("curve_at_index", &getCurveAtIndex, return_internal_reference<>())
-      .def("curve_at_time", &getCurveAtTime, return_internal_reference<>())
+      .def("curve_at_index", &piecewise_t::curve_at_index)
+      .def("curve_at_time", &piecewise_t::curve_at_time)
       .def("num_curves", &piecewise_t::num_curves)
       .def("saveAsText", &piecewise_t::saveAsText<piecewise_t>, bp::args("filename"),
            "Saves *this inside a text file.")
@@ -784,8 +770,8 @@ BOOST_PYTHON_MODULE(curves) {
            "where T_{min} is equal toT_{max} of the actual piecewise curve.")
       .def("is_continuous", &piecewise_bezier_t::is_continuous, "Check if the curve is continuous at the given order.",
            args("self,order"))
-      .def("curve_at_index", &getCurveAtIndex, return_internal_reference<>())
-      .def("curve_at_time", &getCurveAtTime, return_internal_reference<>())
+      .def("curve_at_index", &piecewise_bezier_t::curve_at_index)
+      .def("curve_at_time", &piecewise_bezier_t::curve_at_time)
       .def("num_curves", &piecewise_bezier_t::num_curves)
       .def("saveAsText", &piecewise_bezier_t::saveAsText<piecewise_bezier_t>, bp::args("filename"),
            "Saves *this inside a text file.")
@@ -812,8 +798,8 @@ BOOST_PYTHON_MODULE(curves) {
            "where T_{min} is equal toT_{max} of the actual piecewise curve.")
       .def("is_continuous", &piecewise_linear_bezier_t::is_continuous,
            "Check if the curve is continuous at the given order.", args("self,order"))
-      .def("curve_at_index", &getCurveAtIndex, return_internal_reference<>())
-      .def("curve_at_time", &getCurveAtTime, return_internal_reference<>())
+      .def("curve_at_index", &piecewise_linear_bezier_t::curve_at_index)
+      .def("curve_at_time", &piecewise_linear_bezier_t::curve_at_time)
       .def("num_curves", &piecewise_linear_bezier_t::num_curves)
       .def("saveAsText", &piecewise_linear_bezier_t::saveAsText<piecewise_linear_bezier_t>, bp::args("filename"),
            "Saves *this inside a text file.")
@@ -840,8 +826,8 @@ BOOST_PYTHON_MODULE(curves) {
            args("self,curve"))
       .def("is_continuous", &piecewise_SE3_t::is_continuous, "Check if the curve is continuous at the given order.",
            args("self,order"))
-      .def("curve_at_index", &getCurveAtIndex, return_internal_reference<>())
-      .def("curve_at_time", &getCurveAtTime, return_internal_reference<>())
+      .def("curve_at_index", &piecewise_SE3_t::curve_at_index)
+      .def("curve_at_time", &piecewise_SE3_t::curve_at_time)
       .def("num_curves", &piecewise_SE3_t::num_curves)
       .def("append", &addFinalTransform,
            "Append a new linear SE3 curve at the end of the piecewise curve, defined between self.max() "
@@ -995,9 +981,9 @@ BOOST_PYTHON_MODULE(curves) {
            "translation curve."
            "The orientation along the SE3Curve will be a slerp between the two given rotations."
            "The orientations should be represented as 3x3 rotation matrix")
-      .def("translation_curve",&SE3getTranslationCurve,return_internal_reference<>(),
+      .def("translation_curve",&SE3Curve_t::translation_curve,
       "Return a curve corresponding to the translation part of self.")
-       .def("rotation_curve",&SE3getRotationCurve,return_internal_reference<>(),
+       .def("rotation_curve",&SE3Curve_t::rotation_curve,
       "Return a curve corresponding to the rotation part of self.")
       .def("saveAsText", &SE3Curve_t::saveAsText<SE3Curve_t>, bp::args("filename"), "Saves *this inside a text file.")
       .def("loadFromText", &SE3Curve_t::loadFromText<SE3Curve_t>, bp::args("filename"),

--- a/python/curves/curves_python.cpp
+++ b/python/curves/curves_python.cpp
@@ -14,6 +14,7 @@
 #include <boost/python/call_method.hpp>
 #include <boost/ref.hpp>
 #include <boost/utility.hpp>
+#include <boost/python/register_ptr_to_python.hpp>
 
 namespace curves {
 using namespace boost::python;
@@ -468,6 +469,7 @@ BOOST_PYTHON_MODULE(curves) {
   /*eigenpy::exposeAngleAxis();
   eigenpy::exposeQuaternion();*/
   /** END eigenpy init**/
+  /** Expose base abstracts class for each dimension/type : **/
   class_<curve_abc_t, boost::noncopyable, boost::shared_ptr<curve_abc_callback> >("curve")
       .def("__call__", &curve_abc_t::operator(), "Evaluate the curve at the given time.",
            args("self", "t"))
@@ -555,6 +557,11 @@ BOOST_PYTHON_MODULE(curves) {
            args("self", "t", "N"))
 #endif  // CURVES_WITH_PINOCCHIO_SUPPORT
       ;
+  register_ptr_to_python<curve_ptr_t>();
+  register_ptr_to_python<curve3_ptr_t>();
+  register_ptr_to_python<curve_rotation_ptr_t>();
+  register_ptr_to_python<curve_SE3_ptr_t>();
+  /** END base abstracts class for each dimension/type : **/
 
   /** BEGIN bezier3 curve**/
   class_<bezier3_t, bases<curve_3_t>, boost::shared_ptr<bezier3_t> >("bezier3", init<>())

--- a/python/curves/curves_python.cpp
+++ b/python/curves/curves_python.cpp
@@ -239,6 +239,14 @@ static piecewise_t discretPointToPolynomialC2(const pointX_list_t& points, const
       points_list, points_derivative_list, points_second_derivative_list, time_points_list);
 }
 
+curve_abc_t* getCurveAtIndex(piecewise_t& self, const std::size_t idx){
+  return self.curve_at_index(idx).get();
+}
+
+curve_abc_t* getCurveAtTime(piecewise_t& self, const time_t t){
+  return self.curve_at_time(t).get();
+}
+
 void addFinalPointC0(piecewise_t& self, const pointX_t& end, const real time) {
   if (self.num_curves() == 0)
     throw std::runtime_error(
@@ -741,8 +749,8 @@ BOOST_PYTHON_MODULE(curves) {
       .def("convert_piecewise_curve_to_cubic_hermite",
            &piecewise_t::convert_piecewise_curve_to_cubic_hermite<cubic_hermite_spline_t>,
            "Convert a piecewise curve to to a piecewise cubic hermite spline")
-      .def("curve_at_index", &piecewise_t::curve_at_index, return_value_policy<copy_const_reference>())
-      .def("curve_at_time", &piecewise_t::curve_at_time, return_value_policy<copy_const_reference>())
+      .def("curve_at_index", &getCurveAtIndex, return_internal_reference<>())
+      .def("curve_at_time", &getCurveAtTime, return_internal_reference<>())
       .def("num_curves", &piecewise_t::num_curves)
       .def("saveAsText", &piecewise_t::saveAsText<piecewise_t>, bp::args("filename"),
            "Saves *this inside a text file.")
@@ -769,8 +777,8 @@ BOOST_PYTHON_MODULE(curves) {
            "where T_{min} is equal toT_{max} of the actual piecewise curve.")
       .def("is_continuous", &piecewise_bezier_t::is_continuous, "Check if the curve is continuous at the given order.",
            args("self,order"))
-      .def("curve_at_index", &piecewise_bezier_t::curve_at_index, return_value_policy<copy_const_reference>())
-      .def("curve_at_time", &piecewise_bezier_t::curve_at_time, return_value_policy<copy_const_reference>())
+      .def("curve_at_index", &getCurveAtIndex, return_internal_reference<>())
+      .def("curve_at_time", &getCurveAtTime, return_internal_reference<>())
       .def("num_curves", &piecewise_bezier_t::num_curves)
       .def("saveAsText", &piecewise_bezier_t::saveAsText<piecewise_bezier_t>, bp::args("filename"),
            "Saves *this inside a text file.")
@@ -797,8 +805,8 @@ BOOST_PYTHON_MODULE(curves) {
            "where T_{min} is equal toT_{max} of the actual piecewise curve.")
       .def("is_continuous", &piecewise_linear_bezier_t::is_continuous,
            "Check if the curve is continuous at the given order.", args("self,order"))
-      .def("curve_at_index", &piecewise_linear_bezier_t::curve_at_index, return_value_policy<copy_const_reference>())
-      .def("curve_at_time", &piecewise_linear_bezier_t::curve_at_time, return_value_policy<copy_const_reference>())
+      .def("curve_at_index", &getCurveAtIndex, return_internal_reference<>())
+      .def("curve_at_time", &getCurveAtTime, return_internal_reference<>())
       .def("num_curves", &piecewise_linear_bezier_t::num_curves)
       .def("saveAsText", &piecewise_linear_bezier_t::saveAsText<piecewise_linear_bezier_t>, bp::args("filename"),
            "Saves *this inside a text file.")
@@ -825,8 +833,8 @@ BOOST_PYTHON_MODULE(curves) {
            args("self,curve"))
       .def("is_continuous", &piecewise_SE3_t::is_continuous, "Check if the curve is continuous at the given order.",
            args("self,order"))
-      .def("curve_at_index", &piecewise_SE3_t::curve_at_index, return_value_policy<copy_const_reference>())
-      .def("curve_at_time", &piecewise_SE3_t::curve_at_time, return_value_policy<copy_const_reference>())
+      .def("curve_at_index", &getCurveAtIndex, return_internal_reference<>())
+      .def("curve_at_time", &getCurveAtTime, return_internal_reference<>())
       .def("num_curves", &piecewise_SE3_t::num_curves)
       .def("append", &addFinalTransform,
            "Append a new linear SE3 curve at the end of the piecewise curve, defined between self.max() "

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -422,7 +422,8 @@ class TestCurves(unittest.TestCase):
         self.assertEqual(c0.min(), time_points[0])
         self.assertEqual(c0.max(), time_points[1])
         self.assertEqual(c0.dim(), 3)
-        self.assertTrue(array_equal(polC0(0.5), c0(0.5)))
+        mid_t = (c0.max() + c0.min()) /2.
+        self.assertTrue(array_equal(polC0(mid_t), c0(mid_t)))
 
         polC1 = piecewise.FromPointsList(points, points_derivative, time_points)
         self.assertEqual(polC1.min(), time_points[0, 0])

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -360,6 +360,11 @@ class TestCurves(unittest.TestCase):
         pc.derivate(0.4, 2)
         pc.is_continuous(0)
         pc.is_continuous(1)
+        a0 = pc.curve_at_index(0)
+        self.assertTrue(array_equal(a0(0.5), pc(0.5)))
+        self.assertTrue(a0 == a)
+        a0 = b # should not have any effect
+        self.assertTrue(array_equal(pc.curve_at_index(0)(0.5), a(0.5)))
         # Test serialization
         pc.saveAsText("serialization_pc.test")
         pc_test = piecewise()
@@ -412,6 +417,12 @@ class TestCurves(unittest.TestCase):
         self.assertTrue(not polC0.is_continuous(1))
         for i in range(N):
             self.assertTrue(isclose(polC0(time_points[i, 0]), points[:, i]).all())
+
+        c0 = polC0.curve_at_index(0)
+        self.assertEqual(c0.min(), time_points[0])
+        self.assertEqual(c0.max(), time_points[1])
+        self.assertEqual(c0.dim(), 3)
+        self.assertTrue(array_equal(polC0(0.5), c0(0.5)))
 
         polC1 = piecewise.FromPointsList(points, points_derivative, time_points)
         self.assertEqual(polC1.min(), time_points[0, 0])
@@ -500,6 +511,11 @@ class TestCurves(unittest.TestCase):
         pc.derivate(0.4, 2)
         pc.is_continuous(0)
         pc.is_continuous(1)
+        a0 = pc.curve_at_index(0)
+        self.assertTrue(array_equal(a0(0.5), pc(0.5)))
+        self.assertTrue(a0 == a)
+        a0 = b # should not have any effect
+        self.assertTrue(array_equal(pc.curve_at_index(0)(0.5), a(0.5)))
         # Test serialization
         pc.saveAsText("serialization_pc.test")
         pc_test = piecewise()


### PR DESCRIPTION
* Add a python unit-test highlighting the error in issue https://gepgitlab.laas.fr/loco-3d/curves/issues/32

* Rework the code used to expose the inheritance relationship in python.
In the wrapper used to bind pure virtual methods `boost::python::get_override` do not work correctly in this specific case, now use `call_method` which work correctly in all our use cases.

* Correctly register the shared_pointer of the base abstract classes in boost::Python. Thanks to this changes, some code have been simplified as we can now directly shared_pointer and do not need to `.get()` the raw_pointer anymore. 

CI : https://gepgitlab.laas.fr/pfernbac/curves/pipelines/8310