### PR TITLE
Fix destructors, hidden virtual method

### DIFF
--- a/include/ndcurves/bernstein.h
+++ b/include/ndcurves/bernstein.h
@@ -38,7 +38,7 @@ struct Bern {
   Bern() {}
   Bern(const unsigned int m, const unsigned int i) : m_minus_i(m - i), i_(i), bin_m_i_(bin(m, i)) {}
 
-  ~Bern() {}
+  virtual ~Bern() {}
 
   /// \brief Evaluation of Bernstein polynomial at value u.
   /// \param u : value between 0 and 1.

--- a/include/ndcurves/bezier_curve.h
+++ b/include/ndcurves/bezier_curve.h
@@ -127,9 +127,7 @@ struct bezier_curve : public curve_abc<Time, Numeric, Safe, Point> {
         control_points_(other.control_points_) {}
 
   ///\brief Destructor
-  ~bezier_curve() {
-    // NOTHING
-  }
+  virtual ~bezier_curve() {}
 
   /*Operations*/
   ///  \brief Evaluation of the bezier curve at time t.

--- a/include/ndcurves/curve_constraint.h
+++ b/include/ndcurves/curve_constraint.h
@@ -58,7 +58,7 @@ struct curve_constraints : serialization::Serializable {
   virtual bool operator!=(const curve_constraints& other) const { return !(*this == other); }
 
 
-  ~curve_constraints() {}
+  virtual ~curve_constraints() {}
   point_t init_vel;
   point_t init_acc;
   point_t init_jerk;

--- a/include/ndcurves/exact_cubic.h
+++ b/include/ndcurves/exact_cubic.h
@@ -105,18 +105,6 @@ struct exact_cubic : public piecewise_curve<Time, Numeric, Safe, Point> {
   /// \brief Destructor.
   virtual ~exact_cubic() {}
 
-  /**
-   * @brief isApprox check if other and *this are approximately equals.
-   * Only two curves of the same class can be approximately equals, for comparison between different type of curves see
-   * isEquivalent
-   * @param other the other curve to check
-   * @param prec the precision treshold, default Eigen::NumTraits<Numeric>::dummy_precision()
-   * @return true is the two curves are approximately equals
-   */
-  bool isApprox(const exact_cubic_t& other, const Numeric prec = Eigen::NumTraits<Numeric>::dummy_precision()) const {
-    return piecewise_curve_t::isApprox(other, prec);
-  }
-
   std::size_t getNumberSplines() { return this->getNumberCurves(); }
 
   spline_t getSplineAt(std::size_t index) {

--- a/include/ndcurves/helpers/effector_spline_rotation.h
+++ b/include/ndcurves/helpers/effector_spline_rotation.h
@@ -223,7 +223,7 @@ class effector_spline_rotation {
     // NOTHING
   }
 
-  ~effector_spline_rotation() { delete spline_; }
+  virtual ~effector_spline_rotation() { delete spline_; }
   /* Constructors - destructors */
 
   /*Helpers*/

--- a/include/ndcurves/polynomial.h
+++ b/include/ndcurves/polynomial.h
@@ -211,9 +211,7 @@ struct polynomial : public curve_abc<Time, Numeric, Safe, Point> {
   }
 
   /// \brief Destructor
-  ~polynomial() {
-    // NOTHING
-  }
+  virtual ~polynomial() {}
 
   polynomial(const polynomial& other)
       : dim_(other.dim_),

--- a/include/ndcurves/quadratic_variable.h
+++ b/include/ndcurves/quadratic_variable.h
@@ -43,7 +43,7 @@ struct quadratic_variable {
   quadratic_variable(const point_t& b, const Numeric c = 0)
       : c_(c), b_(b), A_(matrix_x_t::Zero((int)(b.rows()), (int)(b.rows()))), zero(false) {}
 
-  static quadratic_variable_t Zero(size_t dim = 0) { return quadratic_variable_t(); }
+  static quadratic_variable_t Zero(size_t /*dim*/ = 0) { return quadratic_variable_t(); }
 
   // linear evaluation
   Numeric operator()(const Eigen::Ref<const point_t>& val) const {

--- a/include/ndcurves/se3_curve.h
+++ b/include/ndcurves/se3_curve.h
@@ -46,7 +46,7 @@ struct SE3Curve : public curve_abc<Time, Numeric, Safe, Eigen::Transform<Numeric
   SE3Curve() : curve_abc_t(), dim_(3), translation_curve_(), rotation_curve_(), T_min_(0), T_max_(0) {}
 
   /// \brief Destructor
-  ~SE3Curve() {
+  virtual ~SE3Curve() {
     // should we delete translation_curve and rotation_curve here ?
     // better switch to shared ptr
   }

--- a/include/ndcurves/so3_linear.h
+++ b/include/ndcurves/so3_linear.h
@@ -84,9 +84,7 @@ struct SO3Linear : public curve_abc<Time, Numeric, Safe, matrix3_t, point3_t > {
   }
 
   /// \brief Destructor
-  ~SO3Linear() {
-    // NOTHING
-  }
+  virtual ~SO3Linear() {}
 
   SO3Linear(const SO3Linear& other)
       : dim_(other.dim_),


### PR DESCRIPTION
This PR:
1. Adds the virtual keyword to destructors of classes which have virtual methods. This prevents destruction order issues.
2. Removes an unused parameter
3. Removes a method which was hiding the virtual defined in the base class and only forwarded to the hidden method of the base class

After this PR, there are only `-Wdeprecated-copy` warnings remaining.