### PR TITLE
Fixed allocator which triggers a compilation error in clang 13.1.6

### DIFF
--- a/include/ndcurves/cubic_hermite_spline.h
+++ b/include/ndcurves/cubic_hermite_spline.h
@@ -34,7 +34,8 @@ template <typename Time = double, typename Numeric = Time, bool Safe = false,
 struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
   typedef Point point_t;
   typedef std::pair<Point, Point> pair_point_tangent_t;
-  typedef std::vector<pair_point_tangent_t, Eigen::aligned_allocator<pair_point_tangent_t> >
+  typedef std::vector<pair_point_tangent_t,
+                      Eigen::aligned_allocator<pair_point_tangent_t> >
       t_pair_point_tangent_t;
   typedef std::vector<Time> vector_time_t;
   typedef Time time_t;

--- a/include/ndcurves/cubic_hermite_spline.h
+++ b/include/ndcurves/cubic_hermite_spline.h
@@ -34,7 +34,7 @@ template <typename Time = double, typename Numeric = Time, bool Safe = false,
 struct cubic_hermite_spline : public curve_abc<Time, Numeric, Safe, Point> {
   typedef Point point_t;
   typedef std::pair<Point, Point> pair_point_tangent_t;
-  typedef std::vector<pair_point_tangent_t, Eigen::aligned_allocator<Point> >
+  typedef std::vector<pair_point_tangent_t, Eigen::aligned_allocator<pair_point_tangent_t> >
       t_pair_point_tangent_t;
   typedef std::vector<Time> vector_time_t;
   typedef Time time_t;


### PR DESCRIPTION
As a side comment, clang compiler is way much better than gnu (I think). It triggers errors that gnu doesn't.

It would be of tremendous help, if we have CI jobs based on clang.