### PR TITLE
Remove std::unary_function

### DIFF
--- a/include/ndcurves/curve_abc.h
+++ b/include/ndcurves/curve_abc.h
@@ -34,8 +34,7 @@ bool isApprox(const T a, const T b, const T eps = 1e-6) {
 template <typename Time = double, typename Numeric = Time, bool Safe = false,
           typename Point = Eigen::Matrix<Numeric, Eigen::Dynamic, 1>,
           typename Point_derivate = Point>
-struct curve_abc : std::unary_function<Time, Point>,
-                   public serialization::Serializable {
+struct curve_abc : public serialization::Serializable {
   typedef Point point_t;
   typedef Point_derivate point_derivate_t;
   typedef Time time_t;


### PR DESCRIPTION
std::unary_function is deprecated since C++11 and removed in C++17

It doesn't break on GCC/clang (at least up to the version in 20.04 for both and 22.04 for GCC) but it does in VS 2022 with C++17 enabled.

See: https://en.cppreference.com/w/cpp/utility/functional/unary_function

PS: if this is merged, would you mind releasing a new version with this PR included? thanks